### PR TITLE
feat: add Iconoir icon library support

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -1,6 +1,6 @@
 # Unicon CLI Documentation
 
-> 🦄 Command-line interface for browsing and exporting 14,700+ icons
+> 🦄 Command-line interface for browsing and exporting 19,000+ icons
 
 **Quick Install**: `npm install -g @webrenew/unicon` or use `npx @webrenew/unicon`
 
@@ -86,7 +86,7 @@ unicon search <query> [options]
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `--source <id>` | Filter by library (lucide, phosphor, hugeicons, heroicons, tabler, feather, remix, simple-icons) | all |
+| `--source <id>` | Filter by library (lucide, phosphor, hugeicons, heroicons, tabler, feather, remix, simple-icons, iconoir) | all |
 | `--category <name>` | Filter by category | all |
 | `--limit <n>` | Max results | 20 |
 | `--json` | Output as JSON | false |
@@ -774,6 +774,7 @@ curl -X POST "https://unicon.webrenew.com/api/search" \
 | `feather` | 287 | MIT | Simple and clean |
 | `remix` | 2,800+ | Apache-2.0 | Multiple categories |
 | `simple-icons` | 3,300+ | CC0 | Brand logos |
+| `iconoir` | 1,600+ | MIT | Modern outlined icons |
 
 ---
 
@@ -897,7 +898,7 @@ unicon bundle --category Dashboards --format svelte --split -o ./src/icons
 - ✅ Zero bundle bloat
 - ✅ No external dependencies
 - ✅ One file per icon for perfect tree-shaking
-- ✅ 14,700+ icons from 8 libraries in one place
+- ✅ 19,000+ icons from 9 libraries in one place
 
 ### Tree-Shaking Benefits
 

--- a/LLMs.txt
+++ b/LLMs.txt
@@ -4,7 +4,7 @@
 
 ## Project Overview
 
-**Unicon** is an open-source icon library aggregator that provides 14,700+ icons from 8 popular libraries (Lucide, Phosphor, Huge Icons, Heroicons, Tabler, Feather, Remix, Simple Icons) in one unified platform. It's like shadcn/ui but for icons.
+**Unicon** is an open-source icon library aggregator that provides 19,000+ icons from 9 popular libraries (Lucide, Phosphor, Huge Icons, Heroicons, Tabler, Feather, Remix, Simple Icons, Iconoir) in one unified platform. It's like shadcn/ui but for icons.
 
 **Key Features:**
 - AI-powered semantic search using embeddings
@@ -92,7 +92,7 @@ mappings (cross-library equivalents)
 **GET /api/icons** - Paginated icon search
 Query Parameters:
 - `q` (string): Search query
-- `source` (string): Filter by library (lucide|phosphor|hugeicons|heroicons|tabler|feather|remix|simple-icons)
+- `source` (string): Filter by library (lucide|phosphor|hugeicons|heroicons|tabler|feather|remix|simple-icons|iconoir)
 - `limit` (number): Results per page (default: 100, max: 160)
 - `offset` (number): Pagination offset
 - `ai` (boolean): Enable AI search (default: true)
@@ -161,7 +161,8 @@ unicon/
 │   │   ├── tabler.py                 # Tabler extractor
 │   │   ├── feather.py                # Feather extractor
 │   │   ├── remix.py                  # Remix extractor
-│   │   └── simple_icons.py           # Simple Icons extractor
+│   │   ├── simple_icons.py           # Simple Icons extractor
+│   │   └── iconoir.py                # Iconoir extractor
 │   ├── main.py                       # Extraction entry point
 │   └── tmp_extract/                  # Temporary extraction files
 ├── packages/
@@ -661,6 +662,7 @@ See `.claude/sprites/` directory for detailed feature specifications:
 - [Feather Icons](https://feathericons.com) - MIT License
 - [Remix Icon](https://remixicon.com) - Apache-2.0 License
 - [Simple Icons](https://simpleicons.org) - CC0 1.0 Universal
+- [Iconoir](https://iconoir.com) - MIT License
 
 ## Contact & Support
 

--- a/docs/mcp-integration.md
+++ b/docs/mcp-integration.md
@@ -5,7 +5,7 @@ Complete guide to integrating Unicon's icon library with AI assistants via the M
 ## Overview
 
 The Unicon MCP Server allows AI assistants like Claude Desktop and Cursor to:
-- Search through 14,700+ icons from 8 libraries
+- Search through 19,000+ icons from 9 libraries
 - Generate icon components in React, Vue, Svelte, or SVG
 - Access icon metadata and library information
 - Build complete icon sets for projects
@@ -351,7 +351,7 @@ ArrowRight.displayName = 'ArrowRight';
 
 ### `unicon_search_icons`
 
-Search through 14,700+ icons using AI-powered semantic search.
+Search through 19,000+ icons using AI-powered semantic search.
 
 **Parameters:**
 

--- a/packages/cli/docs/SKILL.md
+++ b/packages/cli/docs/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: unicon
-description: Help users add icons to their projects using the Unicon icon library. Unicon provides 14,700+ icons from Lucide, Phosphor, Hugeicons, Heroicons, Tabler, Feather, Remix, and Simple Icons (brand logos). Use when adding icons to React, Vue, Svelte, or web projects; using the unicon CLI to search, get, or bundle icons; setting up .uniconrc.json config; generating tree-shakeable icon components; using the Unicon API; or converting between icon formats.
+description: Help users add icons to their projects using the Unicon icon library. Unicon provides 19,000+ icons from Lucide, Phosphor, Hugeicons, Heroicons, Tabler, Feather, Remix, Simple Icons (brand logos), and Iconoir. Use when adding icons to React, Vue, Svelte, or web projects; using the unicon CLI to search, get, or bundle icons; setting up .uniconrc.json config; generating tree-shakeable icon components; using the Unicon API; or converting between icon formats.
 ---
 
 # Unicon
 
-Unicon is a unified icon library providing 14,700+ icons from 8 popular libraries. Unlike traditional npm packages that bundle thousands of icons, Unicon generates only the icons you need.
+Unicon is a unified icon library providing 19,000+ icons from 9 popular libraries. Unlike traditional npm packages that bundle thousands of icons, Unicon generates only the icons you need.
 
 ## Quick Start
 
@@ -51,6 +51,7 @@ npx @webrenew/unicon search "dashboard"
 | `feather` | 287 | Simple and clean |
 | `remix` | 2,800+ | Multiple categories |
 | `simple-icons` | 3,300+ | Brand logos |
+| `iconoir` | 1,600+ | Modern outlined icons |
 
 ## Common Workflows
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -1,12 +1,12 @@
 # Unicon MCP Server
 
-Model Context Protocol (MCP) server for the Unicon icon library. Connects AI assistants like Claude and Cursor to 14,700+ icons from 8 popular libraries.
+Model Context Protocol (MCP) server for the Unicon icon library. Connects AI assistants like Claude and Cursor to 19,000+ icons from 9 popular libraries.
 
 ## Features
 
 - 🔍 **AI-Powered Search**: Semantic search across all icon libraries
 - 🎨 **Multiple Formats**: Get icons as React, Vue, Svelte, SVG, or JSON
-- 📦 **8 Icon Libraries**: Lucide, Phosphor, Hugeicons, Heroicons, Tabler, Feather, Remix, Simple Icons
+- 📦 **9 Icon Libraries**: Lucide, Phosphor, Hugeicons, Heroicons, Tabler, Feather, Remix, Simple Icons, Iconoir
 - ⚡ **Fast**: Hosted API with local MCP bridge for optimal performance
 
 ## Installation
@@ -86,7 +86,7 @@ Once installed, you can ask your AI assistant:
 
 ### `unicon_search_icons`
 
-Search through 14,700+ icons using semantic search.
+Search through 19,000+ icons using semantic search.
 
 **Parameters:**
 - `query` (required): Search query (e.g., "arrow", "dashboard")

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@webrenew/unicon-mcp-server",
   "version": "1.1.0",
-  "description": "MCP server for Unicon icon library - connects AI assistants to 14,700+ icons",
+  "description": "MCP server for Unicon icon library - connects AI assistants to 19,000+ icons",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -4,7 +4,7 @@
  * Unicon MCP Server
  *
  * Provides Model Context Protocol (MCP) interface for Unicon icon library.
- * Connects AI assistants (Claude, Cursor) to 14,700+ icons from 8 libraries.
+ * Connects AI assistants (Claude, Cursor) to 19,000+ icons from 9 libraries.
  *
  * This is a bridge that proxies MCP requests to the hosted Unicon API.
  *

--- a/public/skills/unicon.md
+++ b/public/skills/unicon.md
@@ -1,11 +1,11 @@
 ---
 name: unicon
-description: Help users add icons to their projects using the Unicon icon library. Unicon provides 14,700+ icons from Lucide, Phosphor, Hugeicons, Heroicons, Tabler, Feather, Remix, and Simple Icons (brand logos). Use when adding icons to React, Vue, Svelte, or web projects; using the unicon CLI to search, get, or bundle icons; setting up .uniconrc.json config; generating tree-shakeable icon components; using the Unicon API; or converting between icon formats.
+description: Help users add icons to their projects using the Unicon icon library. Unicon provides 19,000+ icons from Lucide, Phosphor, Hugeicons, Heroicons, Tabler, Feather, Remix, Simple Icons (brand logos), and Iconoir. Use when adding icons to React, Vue, Svelte, or web projects; using the unicon CLI to search, get, or bundle icons; setting up .uniconrc.json config; generating tree-shakeable icon components; using the Unicon API; or converting between icon formats.
 ---
 
 # Unicon
 
-Unicon is a unified icon library providing 14,700+ icons from 8 popular libraries. Unlike traditional npm packages that bundle thousands of icons, Unicon generates only the icons you need.
+Unicon is a unified icon library providing 19,000+ icons from 9 popular libraries. Unlike traditional npm packages that bundle thousands of icons, Unicon generates only the icons you need.
 
 ## Quick Start
 
@@ -50,6 +50,7 @@ npx @webrenew/unicon search "dashboard"
 | `feather` | 287 | Simple and clean |
 | `remix` | 2,800+ | Multiple categories |
 | `simple-icons` | 3,300+ | Brand logos |
+| `iconoir` | 1,600+ | Modern outlined icons |
 
 ## Common Workflows
 

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -79,6 +79,7 @@ const sourceSchema = z
     "feather",
     "remix",
     "simple-icons",
+    "iconoir",
   ])
   .optional()
   .describe("Filter by icon library");
@@ -158,11 +159,11 @@ function createMcpServer() {
     "unicon_search_icons",
     {
       title: "Search Icons",
-      description: `Search through 14,700+ icons across 8 libraries using semantic search.
+      description: `Search through 19,000+ icons across 9 libraries using semantic search.
 
 Args:
   - query (string): Search query (e.g., 'arrow', 'dashboard', 'user profile')
-  - source (string, optional): Filter by library (lucide, phosphor, hugeicons, heroicons, tabler, feather, remix, simple-icons)
+  - source (string, optional): Filter by library (lucide, phosphor, hugeicons, heroicons, tabler, feather, remix, simple-icons, iconoir)
   - category (string, optional): Filter by category
   - limit (number, optional): Maximum results (1-100, default: 20)
   - offset (number, optional): Skip results for pagination (default: 0)

--- a/src/app/docs/api/page.tsx
+++ b/src/app/docs/api/page.tsx
@@ -7,7 +7,7 @@ import { CodeBlock } from "@/components/ui/code-block";
 
 const PAGE_MARKDOWN = `# Unicon API Reference
 
-REST API for programmatic access to 14,700+ icons across 8 libraries.
+REST API for programmatic access to 19,000+ icons across 9 libraries.
 
 Base URL: \`https://unicon.webrenew.com\`
 
@@ -153,7 +153,7 @@ Access-Control-Allow-Origin: *
 
 export const metadata: Metadata = {
   title: "API Reference | Unicon",
-  description: "REST API documentation for programmatic access to 14,700+ icons. Search, filter, and retrieve icon data in JSON format.",
+  description: "REST API documentation for programmatic access to 19,000+ icons. Search, filter, and retrieve icon data in JSON format.",
   keywords: [
     "icon api",
     "rest api",
@@ -167,7 +167,7 @@ export const metadata: Metadata = {
   },
   openGraph: {
     title: "Unicon API Reference",
-    description: "REST API for programmatic access to 14,700+ icons across 8 libraries.",
+    description: "REST API for programmatic access to 19,000+ icons across 9 libraries.",
     url: "https://unicon.webrenew.com/docs/api",
     type: "website",
   },
@@ -501,6 +501,7 @@ export default function APIDocsPage() {
                   { id: "feather", name: "Feather Icons", count: "287", license: "MIT" },
                   { id: "remix", name: "Remix Icon", count: "2,800+", license: "Apache-2.0" },
                   { id: "simple-icons", name: "Simple Icons", count: "3,300+", license: "CC0" },
+                  { id: "iconoir", name: "Iconoir", count: "1,600+", license: "MIT" },
                 ].map((source, i) => (
                   <tr key={i} className="border-b border-border/50">
                     <td className="py-3 px-4 font-mono text-[var(--accent-aqua)]">{source.id}</td>

--- a/src/app/docs/mcp/page.tsx
+++ b/src/app/docs/mcp/page.tsx
@@ -182,7 +182,7 @@ export default function MCPDocsPage() {
                 Model Context Protocol (MCP)
               </a>{" "}
               is an open protocol that enables AI assistants to connect to external tools and data sources.
-              The Unicon MCP Server lets AI assistants search through 14,700+ icons and generate
+              The Unicon MCP Server lets AI assistants search through 19,000+ icons and generate
               framework-specific components on demand.
             </p>
             <p className="text-white/70 leading-relaxed">
@@ -505,7 +505,7 @@ export default function MCPDocsPage() {
             <div className="p-5 rounded-xl border border-border bg-card">
               <h3 className="font-mono text-[var(--accent-aqua)] font-semibold mb-2">unicon_search_icons</h3>
               <p className="text-sm text-muted-foreground mb-3">
-                Search through 14,700+ icons using AI-powered semantic search.
+                Search through 19,000+ icons using AI-powered semantic search.
               </p>
               <div className="text-xs font-mono text-muted-foreground">
                 <div>Parameters:</div>


### PR DESCRIPTION
Add Iconoir to the sourceSchema enum in the MCP API route and update all documentation to reflect the new library count (19,000+ icons from 9 libraries instead of 14,700+ icons from 8 libraries).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Adds Iconoir support and updates ecosystem to 9 libraries / 19,000+ icons.**
> 
> - Adds `iconoir` to `sourceSchema` enum in `api/mcp` route and tool descriptions
> - Updates documentation and skills: `CLI.md`, `LLMs.txt`, `docs/mcp-integration.md`, `public/skills/unicon.md`, `packages/cli/docs/SKILL.md`
> - Updates MCP server package: README copy and `package.json` description
> - Updates site docs: API page text/metadata and sources table to include `iconoir`
> 
> *All changes are primarily copy/enum updates; no functional logic beyond accepting the new source ID.*
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9f1dadc32adc16a752867fa37e2015bd2ce235c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->