### PR TITLE
fix: resolve accessibility audit failures across all pages

### DIFF
--- a/src/app/b/[slug]/page.tsx
+++ b/src/app/b/[slug]/page.tsx
@@ -107,7 +107,7 @@ export default async function PublicBundlePage({ params }: PageProps) {
   return (
     <div className="min-h-screen flex flex-col">
       <SiteHeader />
-      <main className="flex-1 px-4 lg:px-20 xl:px-40 py-8">
+      <div className="flex-1 px-4 lg:px-20 xl:px-40 py-8">
         <div className="max-w-4xl mx-auto">
           {/* Header */}
           <div className="flex items-start gap-4 mb-8">
@@ -164,7 +164,7 @@ export default async function PublicBundlePage({ params }: PageProps) {
             </p>
           </div>
         </div>
-      </main>
+      </div>
     </div>
   );
 }

--- a/src/app/bundles/[id]/page.tsx
+++ b/src/app/bundles/[id]/page.tsx
@@ -54,9 +54,9 @@ export default async function BundleDetailPage({ params }: PageProps) {
   return (
     <div className="min-h-screen flex flex-col">
       <SiteHeader />
-      <main className="flex-1 px-4 lg:px-20 xl:px-40 py-8">
+      <div className="flex-1 px-4 lg:px-20 xl:px-40 py-8">
         <BundleDetailClient initialBundle={bundle as Bundle} />
-      </main>
+      </div>
     </div>
   );
 }

--- a/src/app/bundles/page.tsx
+++ b/src/app/bundles/page.tsx
@@ -18,11 +18,11 @@ export default async function BundlesPage() {
   return (
     <div className="min-h-screen flex flex-col">
       <SiteHeader />
-      <main className="flex-1 px-4 lg:px-20 xl:px-40 py-8">
+      <div className="flex-1 px-4 lg:px-20 xl:px-40 py-8">
         <div className="max-w-6xl mx-auto">
           <BundlesList isPro={user.isPro} />
         </div>
-      </main>
+      </div>
     </div>
   );
 }

--- a/src/app/cli/layout.tsx
+++ b/src/app/cli/layout.tsx
@@ -12,14 +12,14 @@ export default function CLILayout({
       <SiteHeader variant="docs" />
       <div className="flex-1 flex">
         <DocsSidebar />
-        <main className="flex-1 lg:pl-64 flex flex-col">
+        <div className="flex-1 lg:pl-64 flex flex-col">
           <div className="flex-1 flex justify-center">
             <div className="w-full max-w-5xl">
               {children}
             </div>
           </div>
           <Footer />
-        </main>
+        </div>
       </div>
     </div>
   );

--- a/src/app/docs/layout.tsx
+++ b/src/app/docs/layout.tsx
@@ -18,14 +18,14 @@ export default function DocsLayout({
       <DocsSidebar />
 
       {/* Main content with padding for fixed header */}
-      <main className="pt-14 lg:pl-64 min-h-screen flex flex-col">
+      <div className="pt-14 lg:pl-64 min-h-screen flex flex-col">
         <div className="flex-1 flex justify-center overflow-x-hidden">
           <div className="w-full max-w-5xl min-w-0">
             {children}
           </div>
         </div>
         <Footer />
-      </main>
+      </div>
     </div>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -16,7 +16,7 @@
   --secondary: 0 0% 85%;
   --secondary-foreground: 0 0% 10%;
   --muted: 0 0% 85%;
-  --muted-foreground: 0 0% 40%;
+  --muted-foreground: 0 0% 32%;
   --accent: 0 0% 85%;
   --accent-foreground: 0 0% 10%;
   --destructive: 0 84% 60%;
@@ -58,7 +58,7 @@
   --secondary: 0 0% 15%;
   --secondary-foreground: 0 0% 98%;
   --muted: 0 0% 15%;
-  --muted-foreground: 0 0% 60%;
+  --muted-foreground: 0 0% 65%;
   --accent: 0 0% 15%;
   --accent-foreground: 0 0% 98%;
   --destructive: 0 62% 50%;
@@ -181,5 +181,16 @@
   * {
     scrollbar-width: thin;
     scrollbar-color: #333 hsl(0, 0%, 3%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -184,8 +184,16 @@ export default function RootLayout({
       </head>
       <body className={`${geistSans.variable} ${geistMono.variable} font-sans antialiased flex flex-col min-h-screen`}>
         <ThemeProvider>
+          <a
+            href="#main-content"
+            className="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-[100] focus:px-4 focus:py-2 focus:bg-black focus:text-white focus:rounded-lg focus:text-sm focus:font-medium dark:focus:bg-white dark:focus:text-black"
+          >
+            Skip to main content
+          </a>
           <div className="flex-1">
-            {children}
+            <main id="main-content">
+              {children}
+            </main>
           </div>
           <ConditionalFooter />
           <Toaster />

--- a/src/app/packs/page.tsx
+++ b/src/app/packs/page.tsx
@@ -31,7 +31,7 @@ export default function PacksPage() {
   return (
     <div className="min-h-screen flex flex-col bg-white dark:bg-[hsl(0,0%,3%)]">
       <SiteHeader />
-      <main className="flex-1 px-4 lg:px-20 xl:px-40 py-8 lg:pt-20">
+      <div className="flex-1 px-4 lg:px-20 xl:px-40 py-8 lg:pt-20">
         <div className="max-w-6xl mx-auto">
           {/* Header */}
           <div className="mb-10">
@@ -47,7 +47,7 @@ export default function PacksPage() {
           {/* Grid */}
           <PacksGrid />
         </div>
-      </main>
+      </div>
     </div>
   );
 }

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -64,6 +64,7 @@ function FAQItem({ question, answer }: { question: string; answer: string }) {
     <div className="border-b border-black/5 dark:border-white/5 last:border-0">
       <button
         onClick={() => setIsOpen(!isOpen)}
+        aria-expanded={isOpen}
         className="w-full py-4 flex items-center justify-between text-left hover:text-foreground transition-colors"
       >
         <span className="text-sm font-medium text-foreground pr-4">{question}</span>
@@ -72,6 +73,7 @@ function FAQItem({ question, answer }: { question: string; answer: string }) {
             "w-4 h-4 text-muted-foreground shrink-0 transition-transform duration-200",
             isOpen && "rotate-180"
           )}
+          aria-hidden="true"
         />
       </button>
       <div
@@ -142,7 +144,7 @@ function PricingContent() {
   return (
     <div className="min-h-screen flex flex-col">
       <SiteHeader />
-      <main className="flex-1 px-4 lg:px-20 xl:px-40 py-12">
+      <div className="flex-1 px-4 lg:px-20 xl:px-40 py-12">
         <div className="max-w-4xl mx-auto">
           {/* Header */}
           <div className="text-center mb-12">
@@ -228,7 +230,7 @@ function PricingContent() {
 
               {/* Badge */}
               <div className="relative inline-flex self-start items-center gap-1.5 px-3 py-1.5 border border-[var(--accent-aqua)] rounded-full text-[0.7rem] font-semibold text-[var(--accent-aqua)] uppercase tracking-wide mb-5">
-                ✦ Most Popular
+                <span aria-hidden="true">✦</span> Most Popular
               </div>
 
               <div className="relative mb-1">
@@ -238,9 +240,9 @@ function PricingContent() {
                 </div>
                 <div className="flex items-baseline gap-0.5 mb-1.5">
                   <span className="text-5xl font-bold text-white tracking-tighter">$29</span>
-                  <span className="text-base text-white/50">/year</span>
+                  <span className="text-base text-white/60">/year</span>
                 </div>
-                <p className="text-sm text-white/50 mb-6 leading-relaxed">
+                <p className="text-sm text-white/60 mb-6 leading-relaxed">
                   For teams and power users who need more.
                 </p>
               </div>
@@ -248,7 +250,7 @@ function PricingContent() {
               <ul className="relative space-y-3 mb-7 flex-1">
                 {PRO_FEATURES.map((feature) => (
                   <li key={feature.text} className="flex items-center gap-3">
-                    <span className="w-[18px] h-[18px] flex items-center justify-center text-[var(--accent-mint)] text-sm shrink-0">
+                    <span className="w-[18px] h-[18px] flex items-center justify-center text-[var(--accent-mint)] text-sm shrink-0" aria-hidden="true">
                       ✓
                     </span>
                     <span className="text-sm text-white">{feature.text}</span>
@@ -317,6 +319,7 @@ function PricingContent() {
             </h3>
             <div className="overflow-x-auto">
               <table className="w-full text-sm">
+                <caption className="sr-only">Feature comparison between Free and Pro plans</caption>
                 <thead>
                   <tr className="border-b border-black/10 dark:border-white/10">
                     <th className="text-left py-3 px-4 font-medium text-muted-foreground">Feature</th>
@@ -327,18 +330,18 @@ function PricingContent() {
                 <tbody className="divide-y divide-black/5 dark:divide-white/5">
                   <tr>
                     <td className="py-3 px-4 text-foreground">Icon browsing & search</td>
-                    <td className="py-3 px-4 text-center"><CheckIcon className="w-4 h-4 text-green-500 mx-auto" /></td>
-                    <td className="py-3 px-4 text-center"><CheckIcon className="w-4 h-4 text-green-500 mx-auto" /></td>
+                    <td className="py-3 px-4 text-center"><CheckIcon className="w-4 h-4 text-green-500 mx-auto" aria-hidden="true" /><span className="sr-only">Yes</span></td>
+                    <td className="py-3 px-4 text-center"><CheckIcon className="w-4 h-4 text-green-500 mx-auto" aria-hidden="true" /><span className="sr-only">Yes</span></td>
                   </tr>
                   <tr>
                     <td className="py-3 px-4 text-foreground">Copy & download</td>
-                    <td className="py-3 px-4 text-center"><CheckIcon className="w-4 h-4 text-green-500 mx-auto" /></td>
-                    <td className="py-3 px-4 text-center"><CheckIcon className="w-4 h-4 text-green-500 mx-auto" /></td>
+                    <td className="py-3 px-4 text-center"><CheckIcon className="w-4 h-4 text-green-500 mx-auto" aria-hidden="true" /><span className="sr-only">Yes</span></td>
+                    <td className="py-3 px-4 text-center"><CheckIcon className="w-4 h-4 text-green-500 mx-auto" aria-hidden="true" /><span className="sr-only">Yes</span></td>
                   </tr>
                   <tr>
                     <td className="py-3 px-4 text-foreground">CLI access</td>
-                    <td className="py-3 px-4 text-center"><CheckIcon className="w-4 h-4 text-green-500 mx-auto" /></td>
-                    <td className="py-3 px-4 text-center"><CheckIcon className="w-4 h-4 text-green-500 mx-auto" /></td>
+                    <td className="py-3 px-4 text-center"><CheckIcon className="w-4 h-4 text-green-500 mx-auto" aria-hidden="true" /><span className="sr-only">Yes</span></td>
+                    <td className="py-3 px-4 text-center"><CheckIcon className="w-4 h-4 text-green-500 mx-auto" aria-hidden="true" /><span className="sr-only">Yes</span></td>
                   </tr>
                   <tr>
                     <td className="py-3 px-4 text-foreground">Saved cloud bundles</td>
@@ -347,25 +350,25 @@ function PricingContent() {
                   </tr>
                   <tr>
                     <td className="py-3 px-4 text-foreground flex items-center gap-2">
-                      <GlobeIcon className="w-4 h-4" />
+                      <GlobeIcon className="w-4 h-4" aria-hidden="true" />
                       Public sharing links
                     </td>
-                    <td className="py-3 px-4 text-center text-muted-foreground">-</td>
-                    <td className="py-3 px-4 text-center"><CheckIcon className="w-4 h-4 text-green-500 mx-auto" /></td>
+                    <td className="py-3 px-4 text-center text-muted-foreground"><span aria-hidden="true">-</span><span className="sr-only">No</span></td>
+                    <td className="py-3 px-4 text-center"><CheckIcon className="w-4 h-4 text-green-500 mx-auto" aria-hidden="true" /><span className="sr-only">Yes</span></td>
                   </tr>
                   <tr>
                     <td className="py-3 px-4 text-foreground">Authenticated MCP</td>
-                    <td className="py-3 px-4 text-center text-muted-foreground">-</td>
+                    <td className="py-3 px-4 text-center text-muted-foreground"><span aria-hidden="true">-</span><span className="sr-only">No</span></td>
                     <td className="py-3 px-4 text-center text-[var(--accent-lavender)] text-xs">Coming soon</td>
                   </tr>
                   <tr>
                     <td className="py-3 px-4 text-foreground">Brand kit</td>
-                    <td className="py-3 px-4 text-center text-muted-foreground">-</td>
+                    <td className="py-3 px-4 text-center text-muted-foreground"><span aria-hidden="true">-</span><span className="sr-only">No</span></td>
                     <td className="py-3 px-4 text-center text-[var(--accent-lavender)] text-xs">Coming soon</td>
                   </tr>
                   <tr>
                     <td className="py-3 px-4 text-foreground">Custom uploads</td>
-                    <td className="py-3 px-4 text-center text-muted-foreground">-</td>
+                    <td className="py-3 px-4 text-center text-muted-foreground"><span aria-hidden="true">-</span><span className="sr-only">No</span></td>
                     <td className="py-3 px-4 text-center text-[var(--accent-lavender)] text-xs">Coming soon</td>
                   </tr>
                 </tbody>
@@ -437,7 +440,7 @@ function PricingContent() {
             </p>
           </div>
         </div>
-      </main>
+      </div>
 
       <LoginDialog
         open={loginDialogOpen}
@@ -454,9 +457,9 @@ export default function PricingPage() {
       fallback={
         <div className="min-h-screen flex flex-col">
           <SiteHeader />
-          <main className="flex-1 flex items-center justify-center">
+          <div className="flex-1 flex items-center justify-center">
             <Loader2Icon className="w-6 h-6 animate-spin text-muted-foreground" />
-          </main>
+          </div>
         </div>
       }
     >

--- a/src/components/icons/metallic-icon-browser-header.tsx
+++ b/src/components/icons/metallic-icon-browser-header.tsx
@@ -156,6 +156,7 @@ function TypingTerminal() {
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.5, delay: 0.6 }}
       onClick={handleCopy}
+      aria-label={`Copy command: ${SKILL_COMMAND}`}
       className="group relative flex items-center gap-3 px-4 py-2.5 rounded-lg bg-[#1a1a1a] dark:bg-[#0a0a0a] border border-black/10 dark:border-white/10 font-mono text-sm text-left hover:border-[var(--accent-lavender)]/50 transition-colors mb-8 max-w-full overflow-hidden"
     >
       <span className="text-[var(--accent-mint)] select-none shrink-0">$</span>
@@ -230,7 +231,7 @@ export function MetallicIconBrowserHeader({
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.6, delay: 0.3, ease: "easeOut" }}
-        className="text-black/50 dark:text-white/50 text-sm md:text-base max-w-xl mb-4"
+        className="text-black/60 dark:text-white/60 text-sm md:text-base max-w-xl mb-4"
       >
         Pick icons from popular libraries, preview styles, copy the code. Like shadcn, but for
         icons.
@@ -291,7 +292,7 @@ export function MetallicIconBrowserHeader({
             placeholder="Try 'business icons' or 'celebration'…"
             value={search}
             onChange={(event) => onSearchChange(event.target.value)}
-            className="w-full bg-white dark:bg-[hsl(0,0%,3%)] rounded-lg pl-10 pr-12 py-2.5 text-black dark:text-white placeholder:text-black/30 dark:placeholder:text-white/30 text-sm focus:outline-none focus:ring-0 focus:bg-gray-50 dark:focus:bg-[hsl(0,0%,5%)] transition-colors duration-500"
+            className="w-full bg-white dark:bg-[hsl(0,0%,3%)] rounded-lg pl-10 pr-12 py-2.5 text-black dark:text-white placeholder:text-black/40 dark:placeholder:text-white/40 text-sm focus:outline-none focus:ring-0 focus:bg-gray-50 dark:focus:bg-[hsl(0,0%,5%)] transition-colors duration-500"
             autoComplete="off"
           />
         </div>
@@ -326,9 +327,10 @@ export function MetallicIconBrowserHeader({
             {/* Filters toggle button */}
             <button
               onClick={() => onFiltersExpandedChange(!filtersExpanded)}
+              aria-expanded={filtersExpanded}
               className="flex items-center gap-1.5 text-black/40 dark:text-white/40 hover:text-black/60 dark:hover:text-white/60 transition-colors"
             >
-              <FilterIcon className="w-3.5 h-3.5" />
+              <FilterIcon className="w-3.5 h-3.5" aria-hidden="true" />
               <span className="text-[10px] font-mono uppercase tracking-wider">
                 Filters
               </span>
@@ -338,6 +340,7 @@ export function MetallicIconBrowserHeader({
                 viewBox="0 0 24 24"
                 stroke="currentColor"
                 strokeWidth={2}
+                aria-hidden="true"
               >
                 <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
               </svg>
@@ -354,7 +357,7 @@ export function MetallicIconBrowserHeader({
               <>
                 {/* Library */}
                 <div className="flex items-center gap-2">
-                  <span className="text-[10px] font-mono text-black/30 dark:text-white/30 uppercase tracking-wider">
+                  <span className="text-[10px] font-mono text-black/50 dark:text-white/50 uppercase tracking-wider">
                     Library
                   </span>
                   <div className="flex flex-wrap gap-1.5">
@@ -378,7 +381,7 @@ export function MetallicIconBrowserHeader({
 
                 {/* Category Combobox */}
                 <div className="flex items-center gap-2">
-                  <span className="text-[10px] font-mono text-black/30 dark:text-white/30 uppercase tracking-wider">
+                  <span className="text-[10px] font-mono text-black/50 dark:text-white/50 uppercase tracking-wider">
                     Category
                   </span>
                   <Popover open={categoryOpen} onOpenChange={onCategoryOpenChange}>
@@ -471,9 +474,10 @@ export function MetallicIconBrowserHeader({
           {/* Controls toggle button */}
           <button
             onClick={() => onControlsExpandedChange(!controlsExpanded)}
+            aria-expanded={controlsExpanded}
             className="flex items-center gap-1.5 text-black/40 dark:text-white/40 hover:text-black/60 dark:hover:text-white/60 transition-colors"
           >
-            <SlidersHorizontalIcon className={`w-3.5 h-3.5 transition-transform ${controlsExpanded ? "rotate-90" : ""}`} />
+            <SlidersHorizontalIcon className={`w-3.5 h-3.5 transition-transform ${controlsExpanded ? "rotate-90" : ""}`} aria-hidden="true" />
             <span className="text-[10px] font-mono uppercase tracking-wider">
               Controls
             </span>
@@ -483,6 +487,7 @@ export function MetallicIconBrowserHeader({
               viewBox="0 0 24 24"
               stroke="currentColor"
               strokeWidth={2}
+              aria-hidden="true"
             >
               <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
             </svg>
@@ -493,7 +498,7 @@ export function MetallicIconBrowserHeader({
             <>
               {/* Size Presets */}
               <div className="flex items-center gap-2">
-                <span className="text-[10px] font-mono text-black/30 dark:text-white/30 uppercase tracking-wider">
+                <span className="text-[10px] font-mono text-black/50 dark:text-white/50 uppercase tracking-wider">
                   Size
                 </span>
                 <div className="flex rounded-lg overflow-hidden border border-black/10 dark:border-white/10 bg-black/5 dark:bg-white/5">
@@ -511,7 +516,7 @@ export function MetallicIconBrowserHeader({
                     </button>
                   ))}
                 </div>
-                <span className="text-[10px] font-mono text-black/30 dark:text-white/30">
+                <span className="text-[10px] font-mono text-black/50 dark:text-white/50">
                   {SIZE_PRESETS[sizePreset].px}
                 </span>
               </div>
@@ -521,7 +526,7 @@ export function MetallicIconBrowserHeader({
 
               {/* Stroke Weight Presets */}
               <div className="flex items-center gap-2">
-                <span className="text-[10px] font-mono text-black/30 dark:text-white/30 uppercase tracking-wider">
+                <span className="text-[10px] font-mono text-black/50 dark:text-white/50 uppercase tracking-wider">
                   Weight
                 </span>
                 <div className="flex rounded-lg overflow-hidden border border-black/10 dark:border-white/10 bg-black/5 dark:bg-white/5">

--- a/src/components/icons/metallic-icon-browser-results.tsx
+++ b/src/components/icons/metallic-icon-browser-results.tsx
@@ -137,7 +137,7 @@ export function MetallicIconBrowserResults({
         </>
       ) : (
         <div className="flex flex-col items-center justify-center py-20 text-center">
-          <div className="text-6xl mb-4 opacity-50">🔍</div>
+          <div className="text-6xl mb-4 opacity-50" aria-hidden="true">🔍</div>
           <h3 className="text-lg font-medium text-black/60 dark:text-white/60">No icons found</h3>
           <p className="text-sm text-black/40 dark:text-white/40 mt-1">
             Try adjusting your search or filters

--- a/src/components/icons/styled-icon.tsx
+++ b/src/components/icons/styled-icon.tsx
@@ -253,6 +253,7 @@ export function ${componentName}({ className, ...props }: SVGProps<SVGSVGElement
             onClick={handleClick}
             onMouseEnter={() => onHoverSource?.(icon.sourceId)}
             onMouseLeave={() => onHoverSource?.(null)}
+            aria-label={`${icon.normalizedName} icon from ${icon.sourceId}${isSelected ? ", selected" : ""}`}
             style={containerStyle}
             className={`group relative flex items-center justify-center shrink-0 cursor-pointer transition-all duration-150 hover:scale-105 active:scale-95 overflow-hidden ${styles.container} ${isSelected ? "ring-2 ring-emerald-500 ring-offset-1 ring-offset-white dark:ring-offset-[hsl(0,0%,3%)]" : ""
               }`}

--- a/src/components/mobile-nav.tsx
+++ b/src/components/mobile-nav.tsx
@@ -68,7 +68,12 @@ export function MobileNav({ isOpen, onClose }: MobileNavProps) {
       />
 
       {/* Menu Panel */}
-      <div className="fixed top-14 left-0 right-0 bg-white dark:bg-background border-b border-border z-50 md:hidden animate-in slide-in-from-top-2 duration-200">
+      <div
+        role="dialog"
+        aria-label="Navigation menu"
+        aria-modal="true"
+        className="fixed top-14 left-0 right-0 bg-white dark:bg-background border-b border-border z-50 md:hidden animate-in slide-in-from-top-2 duration-200"
+      >
         <nav className="p-4 space-y-1">
           {navItems.map((item) => {
             const Icon = item.icon;


### PR DESCRIPTION
- Add skip-to-content link and single <main> landmark in root layout
- Remove nested <main> elements from 7 page/layout files
- Add aria-label to icon grid buttons (styled-icon)
- Add aria-expanded to Filters, Controls, and FAQ toggle buttons
- Add aria-hidden to decorative emojis, icons, and SVG chevrons
- Add sr-only text for table checkmarks and dash cells
- Add table caption for pricing comparison
- Improve text contrast: muted-foreground 40%→32% (light), 60%→65% (dark)
- Bump low-opacity text from /30→/50 for labels, /50→/60 for subtitles
- Add prefers-reduced-motion media query to disable animations
- Add dialog role and aria-label to mobile nav panel
- Add aria-label to typing terminal copy button

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily markup/ARIA and CSS tweaks to improve accessibility; low functional risk, with minor potential for layout/semantic regressions if any page relied on nested `<main>` styling.
> 
> **Overview**
> Adds a single, consistent `main` landmark in `src/app/layout.tsx` (including a skip-to-content link) and removes nested `<main>` elements across multiple pages/layouts by converting them to `<div>` wrappers.
> 
> Improves accessibility semantics across UI controls: adds `aria-label`/`aria-expanded`/`aria-modal` and marks decorative icons/emojis as `aria-hidden`, plus adds screen-reader-only text and a caption for the pricing comparison table.
> 
> Tweaks global styling for readability and motion sensitivity by adjusting muted text contrast variables and adding a `prefers-reduced-motion` override to effectively disable animations/transitions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12e64f446d4b454899c2890273e9fd92182341f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->