### PR TITLE
chore: add stale PR/issue cleanup workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,27 @@
+name: Close stale PRs and issues
+
+on:
+  schedule:
+    - cron: "0 9 * * 1" # Every Monday at 9am UTC
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 30
+          days-before-close: 7
+          stale-pr-message: "This PR has been inactive for 30 days. It will be closed in 7 days if there's no activity."
+          stale-issue-message: "This issue has been inactive for 30 days. It will be closed in 7 days if there's no activity."
+          close-pr-message: "Closed due to inactivity. Feel free to reopen if still relevant."
+          close-issue-message: "Closed due to inactivity. Feel free to reopen if still relevant."
+          stale-pr-label: stale
+          stale-issue-label: stale
+          exempt-pr-labels: "pinned,dependencies"
+          exempt-issue-labels: "pinned"


### PR DESCRIPTION
## Summary

- Adds `actions/stale` workflow to auto-close inactive PRs and issues
- 30 days inactive → labeled stale, 7 more days → closed
- Dependabot PRs and pinned items are exempt

## Test plan

- [ ] Workflow runs on schedule or manual dispatch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Repo-maintenance automation only; main risk is unintended closure/labeling if label exemptions or time windows don’t match expectations.
> 
> **Overview**
> Adds a new GitHub Actions workflow (`.github/workflows/stale.yml`) that runs weekly (and via manual dispatch) to mark inactive issues/PRs as `stale` after 30 days, then auto-close them 7 days later with standard notification messages.
> 
> The workflow grants `issues`/`pull-requests` write permissions and exempts `pinned` items and PRs labeled `dependencies` from being marked/closed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 126c30f264973604aec6745797ccdda718e9474f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->