### PR TITLE
fix: reset downgrade loading state when portal URL missing

### DIFF
--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -153,9 +153,10 @@ function PricingContent() {
       }
 
       const data = await res.json();
-      if (data.url) {
-        window.location.href = data.url;
+      if (!data.url) {
+        throw new Error("Failed to open subscription portal");
       }
+      window.location.href = data.url;
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Failed to open subscription portal");
       setIsDowngrading(false);


### PR DESCRIPTION
## Summary

- Throw when Stripe portal response lacks a URL so the catch block resets `isDowngrading` and shows an error toast instead of leaving the button in a permanent loading spinner.

## Test plan

- [ ] Simulate a portal response without a URL — button should reset and show error toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small client-side error-handling change limited to the pricing page’s Stripe portal redirect logic.
> 
> **Overview**
> Fixes the downgrade-to-Stripe-portal flow on the pricing page by treating a missing `url` in the `/api/stripe/portal` response as an error.
> 
> Instead of silently doing nothing (leaving the downgrade button stuck loading), `handleDowngrade` now throws and falls into the existing `catch`, which shows an error toast and resets `isDowngrading`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f007eb9ebd8dd25d62f6438adcfe8ddcbf59042. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->