### PR TITLE
feat: fix logout and add Figma plugin links

### DIFF
--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -13,6 +13,7 @@ import { SparklesIcon } from "@/components/icons/ui/sparkles";
 import { ArrowRightIcon } from "@/components/icons/ui/arrow-right";
 import { ExternalLinkIcon } from "@/components/icons/ui/external-link";
 import { MCPIcon } from "@/components/icons/mcp-icon";
+import { FigmaIcon } from "@/components/icons/ui/figma";
 import { DocsPageNav, getDocsNavLinks } from "@/components/docs-page-nav";
 import { CopyPageButton } from "@/components/copy-page-button";
 
@@ -57,6 +58,9 @@ bunx @webrenew/unicon search "dashboard"     # bun
 ### MCP Server (AI Integration)
 Use Unicon with Claude Desktop, Cursor, or any MCP-compatible AI assistant.
 
+### Figma Plugin
+Browse and insert Unicon icons directly in Figma. Install from the Figma Community.
+
 ## Key Features
 
 - **AI-Powered Search**: Semantic search understands intent. Search for "celebration" and find party, confetti, and cake icons.
@@ -87,6 +91,7 @@ Use Unicon with Claude Desktop, Cursor, or any MCP-compatible AI assistant.
 - MCP Integration: https://unicon.sh/docs/mcp
 - API Reference: https://unicon.sh/docs/api
 - Skills Registry: https://unicon.sh/docs/skills
+- Figma Plugin: https://www.figma.com/community/plugin/1601964333135836232/unicon
 - GitHub: https://github.com/WebRenew/unicon
 `;
 
@@ -251,6 +256,13 @@ export default function DocsPage() {
               description="Use Unicon with Claude Desktop, Cursor, or any MCP-compatible AI assistant."
               href="/docs/mcp"
             />
+            <FeatureCard
+              icon={FigmaIcon}
+              title="Figma Plugin"
+              description="Browse and insert Unicon icons directly in Figma. Install from the Figma Community."
+              href="https://www.figma.com/community/plugin/1601964333135836232/unicon"
+              external
+            />
           </div>
         </section>
 
@@ -348,6 +360,13 @@ export default function DocsPage() {
               title="Skills Registry"
               description="Download AI assistant skills to automate icon workflows."
               href="/docs/skills"
+            />
+            <FeatureCard
+              icon={FigmaIcon}
+              title="Figma Plugin"
+              description="Browse and insert Unicon icons directly in your Figma designs."
+              href="https://www.figma.com/community/plugin/1601964333135836232/unicon"
+              external
             />
             <FeatureCard
               icon={CodeIcon}

--- a/src/components/auth/user-menu.tsx
+++ b/src/components/auth/user-menu.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 import Link from "next/link";
 import {
   Popover,
@@ -21,6 +22,7 @@ interface UserMenuProps {
 }
 
 export function UserMenu({ profile, isPro }: UserMenuProps) {
+  const router = useRouter();
   const [open, setOpen] = useState(false);
   const [isSigningOut, setIsSigningOut] = useState(false);
 
@@ -28,6 +30,8 @@ export function UserMenu({ profile, isPro }: UserMenuProps) {
     setIsSigningOut(true);
     try {
       await signOut();
+      router.push("/");
+      router.refresh();
     } catch {
       setIsSigningOut(false);
     }

--- a/src/components/icons/ui/figma.tsx
+++ b/src/components/icons/ui/figma.tsx
@@ -1,0 +1,25 @@
+import { SVGProps } from "react";
+
+export function FigmaIcon({ className, ...props }: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.75}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      focusable="false"
+      className={className}
+      {...props}
+    >
+      <path d="M5 5.5A3.5 3.5 0 0 1 8.5 2H12v7H8.5A3.5 3.5 0 0 1 5 5.5z" />
+      <path d="M12 2h3.5a3.5 3.5 0 1 1 0 7H12V2z" />
+      <path d="M12 12.5a3.5 3.5 0 1 1 7 0 3.5 3.5 0 1 1-7 0z" />
+      <path d="M5 19.5A3.5 3.5 0 0 1 8.5 16H12v3.5a3.5 3.5 0 1 1-7 0z" />
+      <path d="M5 12.5A3.5 3.5 0 0 1 8.5 9H12v7H8.5A3.5 3.5 0 0 1 5 12.5z" />
+    </svg>
+  );
+}

--- a/src/components/mobile-nav.tsx
+++ b/src/components/mobile-nav.tsx
@@ -7,6 +7,7 @@ import { FileTextIcon } from "@/components/icons/ui/file-text";
 import { TerminalIcon } from "@/components/icons/ui/terminal";
 import { HotPriceIcon } from "@/components/icons/ui/hot-price";
 import { PackageIcon } from "@/components/icons/ui/package";
+import { FigmaIcon } from "@/components/icons/ui/figma";
 import { MCPIcon } from "@/components/icons/mcp-icon";
 import { XIcon } from "@/components/icons/ui/x";
 
@@ -51,6 +52,14 @@ const navItems = [
     color: "text-[var(--accent-mint)]",
     hoverBg: "hover:bg-[var(--accent-mint)]/10",
   },
+  {
+    href: "https://www.figma.com/community/plugin/1601964333135836232/unicon",
+    label: "Figma Plugin",
+    icon: FigmaIcon,
+    color: "text-[var(--accent-lavender)]",
+    hoverBg: "hover:bg-[var(--accent-lavender)]/10",
+    external: true,
+  },
 ];
 
 export function MobileNav({ isOpen, onClose }: MobileNavProps) {
@@ -77,25 +86,49 @@ export function MobileNav({ isOpen, onClose }: MobileNavProps) {
         <nav className="p-4 space-y-1">
           {navItems.map((item) => {
             const Icon = item.icon;
-            const isActive = pathname === item.href || pathname.startsWith(item.href + "/");
+            const isExternal = "external" in item && item.external;
+            const isActive = !isExternal && (pathname === item.href || pathname.startsWith(item.href + "/"));
 
-            return (
-              <Link
-                key={item.href}
-                href={item.href}
-                onClick={onClose}
-                className={cn(
-                  "flex items-center gap-3 px-4 py-3 rounded-lg transition-colors",
-                  item.hoverBg,
-                  isActive ? item.color : "text-muted-foreground"
-                )}
-              >
+            const className = cn(
+              "flex items-center gap-3 px-4 py-3 rounded-lg transition-colors",
+              item.hoverBg,
+              isActive ? item.color : "text-muted-foreground"
+            );
+
+            const content = (
+              <>
                 {item.label === "MCP" ? (
                   <Icon className="w-5 h-5" size={20} />
                 ) : (
                   <Icon className="w-5 h-5" />
                 )}
                 <span className="font-medium">{item.label}</span>
+              </>
+            );
+
+            if (isExternal) {
+              return (
+                <a
+                  key={item.href}
+                  href={item.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={onClose}
+                  className={className}
+                >
+                  {content}
+                </a>
+              );
+            }
+
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                onClick={onClose}
+                className={className}
+              >
+                {content}
               </Link>
             );
           })}

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -8,6 +8,7 @@ import { FileTextIcon } from "@/components/icons/ui/file-text";
 import { UserIcon } from "@/components/icons/ui/user";
 import { HotPriceIcon } from "@/components/icons/ui/hot-price";
 import { PackageIcon } from "@/components/icons/ui/package";
+import { FigmaIcon } from "@/components/icons/ui/figma";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { MCPIcon } from "@/components/icons/mcp-icon";
 import { MobileNav, MobileNavTrigger } from "@/components/mobile-nav";
@@ -81,6 +82,15 @@ export function SiteHeader({ variant = "default" }: SiteHeaderProps) {
                 <HotPriceIcon className="w-3.5 h-3.5" />
                 Pricing
               </Link>
+              <a
+                href="https://www.figma.com/community/plugin/1601964333135836232/unicon"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-muted-foreground hover:text-[var(--accent-lavender)] hover:bg-[var(--accent-lavender)]/5 transition-colors"
+              >
+                <FigmaIcon className="w-3.5 h-3.5" />
+                Figma
+              </a>
             </nav>
           </div>
 

--- a/src/lib/auth/actions.ts
+++ b/src/lib/auth/actions.ts
@@ -55,7 +55,6 @@ export async function signInWithGoogle(redirectPath?: string) {
 export async function signOut() {
   const supabase = await createClient();
   await supabase.auth.signOut();
-  redirect("/");
 }
 
 export async function getUser(): Promise<UserWithSubscription | null> {


### PR DESCRIPTION
## Summary
- Fix sign-out button not working — server action `redirect()` was throwing `NEXT_REDIRECT` caught by client `try/catch`, now uses client-side `router.push` + `router.refresh` instead
- Add Figma plugin link to desktop navbar, mobile nav, and docs page (Getting Started + Quick Links)
- Add `FigmaIcon` component following project icon conventions

## Test plan
- [ ] Click sign out from user menu — should log out and redirect to home
- [ ] Verify Figma link in desktop navbar opens plugin page in new tab
- [ ] Verify Figma link in mobile nav opens plugin page in new tab
- [ ] Check docs page shows Figma Plugin in Getting Started and Quick Links sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/navigation additions plus a small change to logout routing; main risk is unintended post-logout navigation/cache behavior.
> 
> **Overview**
> Adds **Figma Plugin** surface area across the app: a new `FigmaIcon`, new external links in the desktop header and mobile nav (including proper external-link rendering), and new docs-page content/cards pointing to the Figma Community plugin.
> 
> Fixes sign-out flow by removing the server-action `redirect()` from `signOut` and instead navigating client-side after logout (`router.push("/")` + `router.refresh()`), avoiding redirect exceptions being caught by the client handler.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e9c83e5a7bc6f7103819bf00a082a4f05c8ca61. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->