### PR TITLE
feat: add Figma plugin link to all navbars

### DIFF
--- a/src/components/home-header.tsx
+++ b/src/components/home-header.tsx
@@ -8,6 +8,7 @@ import { FileTextIcon } from "@/components/icons/ui/file-text";
 import { PackageIcon } from "@/components/icons/ui/package";
 import { UserIcon } from "@/components/icons/ui/user";
 import { HotPriceIcon } from "@/components/icons/ui/hot-price";
+import { FigmaIcon } from "@/components/icons/ui/figma";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { MCPIcon } from "@/components/icons/mcp-icon";
 import { MobileNav, MobileNavTrigger } from "@/components/mobile-nav";
@@ -108,6 +109,15 @@ export function HomeHeader() {
                 <TerminalIcon className="w-3.5 h-3.5" />
                 CLI
               </Link>
+              <a
+                href="https://www.figma.com/community/plugin/1601964333135836232/unicon"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-muted-foreground hover:text-[var(--accent-lavender)] hover:bg-[var(--accent-lavender)]/5 transition-colors"
+              >
+                <FigmaIcon className="w-3.5 h-3.5" />
+                Figma
+              </a>
               <Link
                 href="/docs/mcp"
                 className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-muted-foreground hover:text-[var(--accent-lavender)] hover:bg-[var(--accent-lavender)]/5 transition-colors"

--- a/src/components/mobile-nav.tsx
+++ b/src/components/mobile-nav.tsx
@@ -32,6 +32,14 @@ const navItems = [
     hoverBg: "hover:bg-[var(--accent-aqua)]/10",
   },
   {
+    href: "https://www.figma.com/community/plugin/1601964333135836232/unicon",
+    label: "Figma Plugin",
+    icon: FigmaIcon,
+    color: "text-[var(--accent-lavender)]",
+    hoverBg: "hover:bg-[var(--accent-lavender)]/10",
+    external: true,
+  },
+  {
     href: "/docs/mcp",
     label: "MCP",
     icon: MCPIcon,
@@ -51,14 +59,6 @@ const navItems = [
     icon: HotPriceIcon,
     color: "text-[var(--accent-mint)]",
     hoverBg: "hover:bg-[var(--accent-mint)]/10",
-  },
-  {
-    href: "https://www.figma.com/community/plugin/1601964333135836232/unicon",
-    label: "Figma Plugin",
-    icon: FigmaIcon,
-    color: "text-[var(--accent-lavender)]",
-    hoverBg: "hover:bg-[var(--accent-lavender)]/10",
-    external: true,
   },
 ];
 

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -61,6 +61,15 @@ export function SiteHeader({ variant = "default" }: SiteHeaderProps) {
                 <TerminalIcon className="w-3.5 h-3.5" />
                 CLI
               </Link>
+              <a
+                href="https://www.figma.com/community/plugin/1601964333135836232/unicon"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-muted-foreground hover:text-[var(--accent-lavender)] hover:bg-[var(--accent-lavender)]/5 transition-colors"
+              >
+                <FigmaIcon className="w-3.5 h-3.5" />
+                Figma
+              </a>
               <Link
                 href="/docs/mcp"
                 className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-muted-foreground hover:text-[var(--accent-lavender)] hover:bg-[var(--accent-lavender)]/5 transition-colors"
@@ -82,15 +91,6 @@ export function SiteHeader({ variant = "default" }: SiteHeaderProps) {
                 <HotPriceIcon className="w-3.5 h-3.5" />
                 Pricing
               </Link>
-              <a
-                href="https://www.figma.com/community/plugin/1601964333135836232/unicon"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-muted-foreground hover:text-[var(--accent-lavender)] hover:bg-[var(--accent-lavender)]/5 transition-colors"
-              >
-                <FigmaIcon className="w-3.5 h-3.5" />
-                Figma
-              </a>
             </nav>
           </div>
 


### PR DESCRIPTION
## Summary
- Added Figma plugin link to homepage navbar (`home-header.tsx`)
- Reordered nav items across all navbars (homepage, docs, mobile) so Figma sits right after CLI
- Consistent order: Docs > CLI > Figma > MCP > Packs > Pricing

## Test plan
- [ ] Verify Figma link appears in homepage navbar after CLI
- [ ] Verify Figma link appears in docs navbar after CLI
- [ ] Verify mobile nav shows Figma after CLI
- [ ] Verify Figma link opens correct URL in new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely UI/navigation link additions and ordering changes with no backend, auth, or data-handling impact.
> 
> **Overview**
> Adds a new external **Figma plugin** link (with `FigmaIcon`) to the desktop nav in `HomeHeader` and `SiteHeader`, opening in a new tab.
> 
> Reorders navigation items so Figma consistently appears immediately after CLI, and updates `MobileNav`’s `navItems` ordering accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad6223efa186ab30a13445c1133aad87be428a45. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->