### PR TITLE
fix: replace img with Next.js Image component

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -32,6 +32,12 @@ const nextConfig: NextConfig = {
   typescript: {
     ignoreBuildErrors: false,
   },
+  images: {
+    remotePatterns: [
+      { hostname: "avatars.githubusercontent.com" },
+      { hostname: "lh3.googleusercontent.com" },
+    ],
+  },
   experimental: {
     // Optimize barrel imports for lucide-react to reduce bundle size
     // This transforms `import { X } from "lucide-react"` to individual imports

--- a/src/app/auth/device/page.tsx
+++ b/src/app/auth/device/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, Suspense } from "react";
 import { useSearchParams } from "next/navigation";
+import Image from "next/image";
 import Link from "next/link";
 import { useAuth } from "@/hooks/use-auth";
 import { LoginDialog } from "@/components/auth/login-dialog";
@@ -137,10 +138,11 @@ function DeviceAuthContent() {
               {/* User info */}
               {user && (
                 <div className="flex items-center gap-3 p-3 bg-muted/50 rounded-lg mb-6">
-                  {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img
+                  <Image
                     src={user.user_metadata?.avatar_url || "/placeholder-avatar.png"}
                     alt=""
+                    width={40}
+                    height={40}
                     className="w-10 h-10 rounded-full"
                   />
                   <div className="flex-1 min-w-0">

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,4 +1,5 @@
 import { redirect } from "next/navigation";
+import Image from "next/image";
 import Link from "next/link";
 import { SiteHeader } from "@/components/site-header";
 import { getUser } from "@/lib/auth/actions";
@@ -100,10 +101,11 @@ export default async function SettingsPage() {
             <div className="flex items-center gap-4">
               <div className="relative w-12 h-12 rounded-full overflow-hidden bg-black/10 dark:bg-white/10 flex items-center justify-center shrink-0">
                 {profile.avatar_url ? (
-                  // eslint-disable-next-line @next/next/no-img-element
-                  <img
+                  <Image
                     src={profile.avatar_url}
                     alt={displayName}
+                    width={48}
+                    height={48}
                     className="w-full h-full object-cover"
                   />
                 ) : (

--- a/src/components/auth/user-menu.tsx
+++ b/src/components/auth/user-menu.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import Image from "next/image";
 import Link from "next/link";
 import {
   Popover,
@@ -54,10 +55,11 @@ export function UserMenu({ profile, isPro }: UserMenuProps) {
           aria-label="User menu"
         >
           {avatarUrl ? (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img
+            <Image
               src={avatarUrl}
               alt={displayName}
+              width={32}
+              height={32}
               className="w-full h-full rounded-full object-cover"
             />
           ) : (

--- a/src/components/settings/team-settings.tsx
+++ b/src/components/settings/team-settings.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback } from "react";
+import Image from "next/image";
 import { UsersIcon } from "@/components/icons/ui/users";
 import { UserPlusIcon } from "@/components/icons/ui/user-plus";
 import { MailIcon } from "@/components/icons/ui/mail";
@@ -313,10 +314,11 @@ function MemberRow({
       <div className="flex items-center gap-3 min-w-0">
         <div className="w-7 h-7 rounded-full bg-black/10 dark:bg-white/10 flex items-center justify-center shrink-0">
           {profile?.avatar_url ? (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img
+            <Image
               src={profile.avatar_url}
               alt={displayName}
+              width={28}
+              height={28}
               className="w-full h-full rounded-full object-cover"
             />
           ) : (


### PR DESCRIPTION
## Summary
- Removed all 4 `eslint-disable` comments for `@next/next/no-img-element`
- Replaced `<img>` tags with Next.js `Image` component in avatar renders
- Added `images.remotePatterns` in `next.config.ts` for GitHub and Google avatar domains
- Used explicit `width`/`height` props matching each avatar's rendered size (48, 40, 32, 28px)

## Files changed
- `next.config.ts` — added remotePatterns config
- `src/app/settings/page.tsx` — 48x48 profile avatar
- `src/components/auth/user-menu.tsx` — 32x32 header avatar
- `src/app/auth/device/page.tsx` — 40x40 device auth avatar
- `src/components/settings/team-settings.tsx` — 28x28 team member avatar

## Verification
- [x] `pnpm typecheck` passes
- [x] `pnpm build` passes
- [x] `pnpm lint` passes
- [x] No `eslint-disable` comments for `no-img-element` remain in src/

🤖 Generated by refactor-loop

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only refactor plus a small Next.js image configuration change; main risk is broken avatar loading if additional remote hosts are used.
> 
> **Overview**
> Replaces avatar rendering in the device auth page, settings profile card, user menu, and team member list to use `next/image` (with explicit `width`/`height`) and removes the related `no-img-element` eslint suppressions.
> 
> Updates `next.config.ts` to allow loading remote avatars via `images.remotePatterns` for `avatars.githubusercontent.com` and `lh3.googleusercontent.com`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe18d13590f7761daa57563d4a9ebca0a87517a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->