### PR TITLE
feat: add OpenClaw auto-install metadata to skills

### DIFF
--- a/skills/unicon-mcp/SKILL.md
+++ b/skills/unicon-mcp/SKILL.md
@@ -8,6 +8,14 @@ metadata:
   version: "1.0.0"
   website: https://unicon.sh
   repository: https://github.com/WebRenew/unicon
+  openclaw:
+    emoji: "🔌"
+    requires:
+      bins: ["node", "npx"]
+    install:
+      - type: node
+        package: "@webrenew/unicon-mcp-server"
+        global: true
 ---
 
 # Unicon MCP

--- a/skills/unicon/SKILL.md
+++ b/skills/unicon/SKILL.md
@@ -7,6 +7,14 @@ metadata:
   version: "0.2.0"
   website: https://unicon.sh
   repository: https://github.com/WebRenew/unicon
+  openclaw:
+    emoji: "🦄"
+    requires:
+      bins: ["node"]
+    install:
+      - type: node
+        package: "@webrenew/unicon"
+        global: true
 ---
 
 # Unicon


### PR DESCRIPTION
## Summary
- Add `metadata.openclaw` to `skills/unicon/SKILL.md` — requires `node`, auto-installs `@webrenew/unicon` globally
- Add `metadata.openclaw` to `skills/unicon-mcp/SKILL.md` — requires `node`+`npx`, auto-installs `@webrenew/unicon-mcp-server` globally

## Test plan
- [ ] Verify YAML parses correctly in both Claude Code and OpenClaw
- [ ] Confirm existing Claude Code metadata is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/YAML metadata-only change that affects installation automation hints but does not modify runtime code or security-sensitive logic.
> 
> **Overview**
> Adds **OpenClaw integration metadata** to the `unicon` and `unicon-mcp` skills.
> 
> Each skill now declares an `openclaw` block (emoji, required binaries, and a global npm package to install), enabling OpenClaw clients to auto-install `@webrenew/unicon` or `@webrenew/unicon-mcp-server` as part of setup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed5175b673286d5b1d8f983e83ae8def14b37dee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->