### PR TITLE
fix: read CLI version from package.json instead of hardcoded value

### DIFF
--- a/LLMs.txt
+++ b/LLMs.txt
@@ -653,6 +653,9 @@ See `.claude/sprites/` directory for detailed feature specifications:
 - [Vercel AI SDK](https://sdk.vercel.ai)
 - [Radix UI](https://www.radix-ui.com/primitives/docs/overview/introduction)
 
+### AI Integration
+- [OpenClaw Skill](https://clawhub.ai/charlesrhoward/unicon) - Claude Code skill for Unicon
+
 ### Icon Libraries
 - [Lucide](https://lucide.dev) - ISC License
 - [Phosphor Icons](https://phosphoricons.com) - MIT License

--- a/packages/cli/dist/index.js
+++ b/packages/cli/dist/index.js
@@ -8,10 +8,13 @@ import figlet from "figlet";
 import { writeFileSync, readFileSync, mkdirSync, existsSync, readdirSync, unlinkSync } from "fs";
 import { dirname, resolve, join, extname } from "path";
 import { homedir } from "os";
+import { createRequire } from "module";
 import { createInterface } from "readline";
 import * as p from "@clack/prompts";
 import clipboard from "clipboardy";
 import chokidar from "chokidar";
+var require2 = createRequire(import.meta.url);
+var { version: CLI_VERSION } = require2("../package.json");
 function confirm2(message) {
   const rl = createInterface({
     input: process.stdin,
@@ -616,7 +619,7 @@ function generateJsonBundle(icons) {
   );
 }
 var program = new Command();
-program.name("unicon").description("CLI for searching and bundling icons from Unicon").version("0.1.0").hook("preAction", (thisCommand) => {
+program.name("unicon").description("CLI for searching and bundling icons from Unicon").version(CLI_VERSION).hook("preAction", (thisCommand) => {
   if (thisCommand.args.length === 0 || process.argv.includes("--help") || process.argv.includes("-h")) {
     return;
   }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -7,10 +7,14 @@ import figlet from "figlet";
 import { writeFileSync, readFileSync, mkdirSync, existsSync, readdirSync, unlinkSync } from "fs";
 import { dirname, resolve, join, extname } from "path";
 import { homedir } from "os";
+import { createRequire } from "module";
 import { createInterface } from "readline";
 import * as p from "@clack/prompts";
 import clipboard from "clipboardy";
 import chokidar from "chokidar";
+
+const require = createRequire(import.meta.url);
+const { version: CLI_VERSION } = require("../package.json") as { version: string };
 
 /**
  * Simple yes/no confirmation prompt
@@ -913,7 +917,7 @@ const program = new Command();
 program
   .name("unicon")
   .description("CLI for searching and bundling icons from Unicon")
-  .version("0.1.0")
+  .version(CLI_VERSION)
   .hook("preAction", (thisCommand) => {
     // Show banner only for main commands, not subcommands
     if (thisCommand.args.length === 0 || process.argv.includes("--help") || process.argv.includes("-h")) {


### PR DESCRIPTION
## Summary
- CLI was reporting `0.1.0` while `package.json` had `0.3.2` because the version was hardcoded in `src/index.ts`
- Now uses `createRequire` to read version from `package.json` dynamically so it won't drift again
- Adds OpenClaw skill link to `LLMs.txt`

## Test plan
- [x] `unicon --version` returns `0.3.2` (matches package.json)
- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm build` passes
- [x] CLI build (`packages/cli`) succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to CLI metadata and a docs-only update; minimal behavioral impact beyond `--version` output.
> 
> **Overview**
> Fixes CLI version drift by reading the `unicon` CLI version from `packages/cli/package.json` at runtime (via `createRequire`) instead of a hardcoded string, updating both `src/index.ts` and the built `dist/index.js`.
> 
> Also adds an **AI Integration** resource link (OpenClaw skill) to `LLMs.txt`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba43f7fcd49d4b8e3cc4da418699708c6373d7e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->