### PR TITLE
feat: add API token management to settings page

### DIFF
--- a/src/app/api/auth/tokens/[sessionId]/route.ts
+++ b/src/app/api/auth/tokens/[sessionId]/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+
+/**
+ * DELETE /api/auth/tokens/[sessionId] — Revoke an API token
+ */
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ sessionId: string }> }
+) {
+  const { sessionId } = await params;
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const admin = createAdminClient();
+  const { data, error } = await admin.rpc("revoke_api_session", {
+    p_session_id: sessionId,
+    p_user_id: user.id,
+  });
+
+  if (error) {
+    logger.error("revoke_api_session error:", error);
+    return NextResponse.json({ error: "Failed to revoke token" }, { status: 500 });
+  }
+
+  if (!data) {
+    return NextResponse.json({ error: "Token not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/auth/tokens/route.ts
+++ b/src/app/api/auth/tokens/route.ts
@@ -1,0 +1,84 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+
+/**
+ * GET /api/auth/tokens — List active API tokens for the current user
+ */
+export async function GET() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const admin = createAdminClient();
+  const { data, error } = await admin.rpc("list_api_sessions", {
+    p_user_id: user.id,
+  });
+
+  if (error) {
+    logger.error("list_api_sessions error:", error);
+    return NextResponse.json({ error: "Failed to list tokens" }, { status: 500 });
+  }
+
+  return NextResponse.json({ sessions: data ?? [] });
+}
+
+/**
+ * POST /api/auth/tokens — Generate a new API token (Pro users only)
+ */
+export async function POST(request: Request) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: Record<string, unknown> = {};
+  try {
+    body = await request.json();
+  } catch {
+    // No body is fine — name is optional
+  }
+
+  const name = typeof body.name === "string" ? body.name.trim() || null : null;
+
+  const admin = createAdminClient();
+  const { data, error } = await admin.rpc("create_api_token_direct", {
+    p_user_id: user.id,
+    p_name: name,
+    p_scope: "bundles:read",
+  });
+
+  if (error) {
+    logger.error("create_api_token_direct error:", error);
+    return NextResponse.json({ error: "Failed to generate token" }, { status: 500 });
+  }
+
+  const result = data as unknown as Record<string, unknown>;
+
+  if (result.error) {
+    return NextResponse.json(
+      { error: result.error as string },
+      { status: 403 }
+    );
+  }
+
+  return NextResponse.json(
+    {
+      session_id: result.session_id,
+      access_token: result.access_token,
+    },
+    { status: 201 }
+  );
+}

--- a/src/app/api/bundles/route.ts
+++ b/src/app/api/bundles/route.ts
@@ -1,84 +1,96 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+import { logger } from "@/lib/logger";
 
 export async function GET() {
-  const supabase = await createClient();
+  try {
+    const supabase = await createClient();
 
-  const { data: { user }, error: authError } = await supabase.auth.getUser();
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
 
-  if (authError || !user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  const { data: bundles, error } = await supabase
-    .from("bundles")
-    .select("*")
-    .eq("user_id", user.id)
-    .order("updated_at", { ascending: false });
-
-  if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
-  }
-
-  return NextResponse.json(
-    { bundles },
-    {
-      headers: {
-        "Cache-Control": "private, max-age=30, stale-while-revalidate=60",
-        "Vary": "Cookie",
-      },
+    if (authError || !user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
-  );
+
+    const { data: bundles, error } = await supabase
+      .from("bundles")
+      .select("*")
+      .eq("user_id", user.id)
+      .order("updated_at", { ascending: false });
+
+    if (error) {
+      logger.error("GET /api/bundles query error:", error);
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json(
+      { bundles },
+      {
+        headers: {
+          "Cache-Control": "private, max-age=30, stale-while-revalidate=60",
+          "Vary": "Cookie",
+        },
+      }
+    );
+  } catch (err) {
+    logger.error("GET /api/bundles error:", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
 }
 
 export async function POST(request: Request) {
-  const supabase = await createClient();
-
-  const { data: { user }, error: authError } = await supabase.auth.getUser();
-
-  if (authError || !user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  // Parse body early to fail fast on invalid input
-  let body: Record<string, unknown>;
   try {
-    body = await request.json();
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    const supabase = await createClient();
+
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    // Parse body early to fail fast on invalid input
+    let body: Record<string, unknown>;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+
+    const { name, description, icons, stroke_preset, normalize_strokes, target_stroke_width, normalize_viewbox, target_viewbox } = body;
+
+    if (!name || !icons || !Array.isArray(icons)) {
+      return NextResponse.json({ error: "Name and icons are required" }, { status: 400 });
+    }
+
+    // Use atomic RPC to prevent race conditions on bundle limit
+    const { data, error } = await supabase.rpc("create_bundle_atomic", {
+      p_user_id: user.id,
+      p_name: name,
+      p_description: description ?? null,
+      p_icons: icons,
+      p_stroke_preset: stroke_preset ?? null,
+      p_normalize_strokes: normalize_strokes ?? false,
+      p_target_stroke_width: target_stroke_width ?? null,
+      p_normalize_viewbox: normalize_viewbox ?? false,
+      p_target_viewbox: target_viewbox ?? "0 0 24 24",
+    });
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    const result = data?.[0];
+
+    if (!result?.success) {
+      return NextResponse.json(
+        { error: result?.error ?? "Failed to create bundle" },
+        { status: 403 }
+      );
+    }
+
+    return NextResponse.json({ bundle: result.bundle }, { status: 201 });
+  } catch (err) {
+    logger.error("POST /api/bundles error:", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
-
-  const { name, description, icons, stroke_preset, normalize_strokes, target_stroke_width, normalize_viewbox, target_viewbox } = body;
-
-  if (!name || !icons || !Array.isArray(icons)) {
-    return NextResponse.json({ error: "Name and icons are required" }, { status: 400 });
-  }
-
-  // Use atomic RPC to prevent race conditions on bundle limit
-  const { data, error } = await supabase.rpc("create_bundle_atomic", {
-    p_user_id: user.id,
-    p_name: name,
-    p_description: description ?? null,
-    p_icons: icons,
-    p_stroke_preset: stroke_preset ?? null,
-    p_normalize_strokes: normalize_strokes ?? false,
-    p_target_stroke_width: target_stroke_width ?? null,
-    p_normalize_viewbox: normalize_viewbox ?? false,
-    p_target_viewbox: target_viewbox ?? "0 0 24 24",
-  });
-
-  if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
-  }
-
-  const result = data?.[0];
-
-  if (!result?.success) {
-    return NextResponse.json(
-      { error: result?.error ?? "Failed to create bundle" },
-      { status: 403 }
-    );
-  }
-
-  return NextResponse.json({ bundle: result.bundle }, { status: 201 });
 }

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -6,8 +6,9 @@ import { getUser } from "@/lib/auth/actions";
 import { CrownIcon } from "@/components/icons/ui/crown";
 import { ManageSubscriptionButton } from "./manage-subscription-button";
 import { TeamSettings } from "@/components/settings/team-settings";
+import { ApiTokenSettings } from "@/components/settings/api-token-settings";
 import { createAdminClient } from "@/lib/supabase/admin";
-import type { TeamWithMembers } from "@/types/database";
+import type { TeamWithMembers, ApiSession } from "@/types/database";
 
 export const metadata = {
   title: "Settings",
@@ -40,14 +41,24 @@ export default async function SettingsPage() {
 
   // Fetch team data for Pro users
   let teamData: TeamWithMembers | null = null;
+  let tokenSessions: ApiSession[] = [];
   if (isPro) {
     const admin = createAdminClient();
-    const { data: membership } = await admin
-      .from("team_members")
-      .select("team_id")
-      .eq("user_id", profile.id)
-      .limit(1)
-      .maybeSingle();
+
+    // Fetch team membership and API sessions in parallel
+    const [membershipResult, sessionsResult] = await Promise.all([
+      admin
+        .from("team_members")
+        .select("team_id")
+        .eq("user_id", profile.id)
+        .limit(1)
+        .maybeSingle(),
+      admin.rpc("list_api_sessions", { p_user_id: profile.id }),
+    ]);
+
+    tokenSessions = (sessionsResult.data ?? []) as unknown as ApiSession[];
+
+    const membership = membershipResult.data;
 
     if (membership) {
       const [teamResult, membersResult, invitesResult] = await Promise.all([
@@ -178,6 +189,11 @@ export default async function SettingsPage() {
               )}
             </div>
           </div>
+
+          {/* API Tokens card (Pro users only) */}
+          {isPro && (
+            <ApiTokenSettings initialSessions={tokenSessions} />
+          )}
 
           {/* Team card (Pro users only) */}
           {isPro && (

--- a/src/components/icons/ui/key.tsx
+++ b/src/components/icons/ui/key.tsx
@@ -1,0 +1,30 @@
+/**
+ * Key icon from Unicon library (lucide:key-round)
+ */
+
+interface IconProps {
+  className?: string;
+  size?: number;
+}
+
+export function KeyIcon({ className, size = 24 }: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      focusable="false"
+      className={className}
+    >
+      <path d="M2.586 17.414A2 2 0 0 0 2 18.828V21a1 1 0 0 0 1 1h3a1 1 0 0 0 1-1v-1a1 1 0 0 1 1-1h1a1 1 0 0 0 1-1v-1a1 1 0 0 1 1-1h.172a2 2 0 0 0 1.414-.586l.814-.814a6.5 6.5 0 1 0-4-4z" />
+      <circle cx="16.5" cy="7.5" r=".5" fill="currentColor" />
+    </svg>
+  );
+}

--- a/src/components/settings/api-token-settings.tsx
+++ b/src/components/settings/api-token-settings.tsx
@@ -1,0 +1,324 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { KeyIcon } from "@/components/icons/ui/key";
+import { PlusIcon } from "@/components/icons/ui/plus";
+import { Loader2Icon } from "@/components/icons/ui/loader-2";
+import { Trash2Icon } from "@/components/icons/ui/trash-2";
+import { CopyIcon } from "@/components/icons/ui/copy";
+import { CheckIcon } from "@/components/icons/ui/check";
+import type { ApiSession } from "@/types/database";
+
+interface ApiTokenSettingsProps {
+  initialSessions: ApiSession[];
+}
+
+export function ApiTokenSettings({ initialSessions }: ApiTokenSettingsProps) {
+  const [sessions, setSessions] = useState<ApiSession[]>(initialSessions);
+  const [showForm, setShowForm] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  return (
+    <div className="p-5 rounded-xl border border-black/5 dark:border-white/5 bg-white/50 dark:bg-white/[0.02]">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-sm font-medium text-muted-foreground">
+          API Tokens
+        </h2>
+        <span className="text-xs text-muted-foreground">
+          {sessions.length} active
+        </span>
+      </div>
+
+      <div className="flex items-center gap-3 mb-5">
+        <div className="w-10 h-10 rounded-lg bg-black/5 dark:bg-white/5 flex items-center justify-center">
+          <KeyIcon className="w-5 h-5 text-muted-foreground" />
+        </div>
+        <div>
+          <p className="text-sm font-medium text-black dark:text-white">
+            Personal API tokens
+          </p>
+          <p className="text-xs text-muted-foreground">
+            Use tokens with SSE/MCP clients like v0, Cursor, and others
+          </p>
+        </div>
+      </div>
+
+      {/* Token list */}
+      {sessions.length > 0 && (
+        <div className="space-y-1.5 mb-4">
+          {sessions.map((session) => (
+            <TokenRow
+              key={session.id}
+              session={session}
+              onRevoked={(id) => {
+                setSessions((prev) => prev.filter((s) => s.id !== id));
+                setError(null);
+              }}
+              setError={setError}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Generate form */}
+      {showForm ? (
+        <GenerateForm
+          onGenerated={(session) => {
+            setSessions((prev) => [session, ...prev]);
+            setShowForm(false);
+            setError(null);
+          }}
+          onCancel={() => setShowForm(false)}
+          setError={setError}
+        />
+      ) : (
+        <button
+          onClick={() => {
+            setShowForm(true);
+            setError(null);
+          }}
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-md border border-black/10 dark:border-white/10 text-black/70 dark:text-white/70 hover:bg-black/5 dark:hover:bg-white/5 transition-colors"
+        >
+          <PlusIcon className="w-3.5 h-3.5" />
+          Generate Token
+        </button>
+      )}
+
+      {error && (
+        <p className="text-xs text-red-600 dark:text-red-400 mt-3">{error}</p>
+      )}
+    </div>
+  );
+}
+
+// --- Token Row ---
+
+function TokenRow({
+  session,
+  onRevoked,
+  setError,
+}: {
+  session: ApiSession;
+  onRevoked: (id: string) => void;
+  setError: (error: string | null) => void;
+}) {
+  const [revoking, setRevoking] = useState(false);
+
+  async function handleRevoke() {
+    setRevoking(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/auth/tokens/${session.id}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.error || "Failed to revoke token");
+        return;
+      }
+      onRevoked(session.id);
+    } catch {
+      setError("Failed to revoke token");
+    } finally {
+      setRevoking(false);
+    }
+  }
+
+  const lastUsed = session.last_used_at
+    ? formatRelativeDate(session.last_used_at)
+    : "Never used";
+
+  return (
+    <div className="flex items-center justify-between py-1.5">
+      <div className="flex items-center gap-3 min-w-0">
+        <div className="w-7 h-7 rounded-full bg-black/5 dark:bg-white/5 flex items-center justify-center shrink-0">
+          <KeyIcon className="w-3.5 h-3.5 text-muted-foreground" />
+        </div>
+        <div className="min-w-0">
+          <p className="text-sm text-black dark:text-white truncate">
+            {session.name || session.client_name}
+          </p>
+          <div className="flex items-center gap-2">
+            <code className="text-xs text-muted-foreground font-mono">
+              {session.token_preview}
+            </code>
+            <span className="text-xs text-muted-foreground">
+              {lastUsed}
+            </span>
+          </div>
+        </div>
+      </div>
+      <button
+        onClick={handleRevoke}
+        disabled={revoking}
+        className="p-1 rounded hover:bg-red-500/10 text-muted-foreground hover:text-red-600 dark:hover:text-red-400 transition-colors disabled:opacity-50 shrink-0"
+        title="Revoke token"
+      >
+        {revoking ? (
+          <Loader2Icon className="w-3.5 h-3.5 animate-spin" />
+        ) : (
+          <Trash2Icon className="w-3.5 h-3.5" />
+        )}
+      </button>
+    </div>
+  );
+}
+
+// --- Generate Form ---
+
+function GenerateForm({
+  onGenerated,
+  onCancel,
+  setError,
+}: {
+  onGenerated: (session: ApiSession) => void;
+  onCancel: () => void;
+  setError: (error: string | null) => void;
+}) {
+  const [name, setName] = useState("");
+  const [generating, setGenerating] = useState(false);
+  const [newToken, setNewToken] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(async () => {
+    if (!newToken) return;
+    try {
+      await navigator.clipboard.writeText(newToken);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Silently fail
+    }
+  }, [newToken]);
+
+  async function handleGenerate(e: React.FormEvent) {
+    e.preventDefault();
+    setGenerating(true);
+    setError(null);
+
+    try {
+      const res = await fetch("/api/auth/tokens", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: name.trim() || undefined }),
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        setError(data.error || "Failed to generate token");
+        return;
+      }
+
+      setNewToken(data.access_token);
+
+      // Add to the list with a preview
+      const token = data.access_token as string;
+      onGenerated({
+        id: data.session_id,
+        name: name.trim() || null,
+        client_name: "Web",
+        scope: "bundles:read",
+        last_used_at: null,
+        created_at: new Date().toISOString(),
+        token_preview: "uni_****" + token.slice(-4),
+      });
+    } catch {
+      setError("Failed to generate token");
+    } finally {
+      setGenerating(false);
+    }
+  }
+
+  // Show the new token once generated
+  if (newToken) {
+    return (
+      <div className="space-y-3">
+        <div className="p-3 rounded-lg border border-emerald-500/20 bg-emerald-500/5">
+          <p className="text-xs font-medium text-emerald-600 dark:text-emerald-400 mb-2">
+            Token created — copy it now, you won&apos;t see it again
+          </p>
+          <div className="flex items-center gap-2">
+            <code className="flex-1 text-sm font-mono text-black dark:text-white bg-black/5 dark:bg-white/5 px-2 py-1 rounded break-all select-all">
+              {newToken}
+            </code>
+            <button
+              type="button"
+              onClick={handleCopy}
+              className="p-1.5 rounded-md transition-colors text-muted-foreground hover:text-black dark:hover:text-white hover:bg-black/5 dark:hover:bg-white/5 shrink-0"
+              aria-label={copied ? "Copied" : "Copy token"}
+            >
+              {copied ? (
+                <CheckIcon className="w-4 h-4 text-emerald-500" />
+              ) : (
+                <CopyIcon className="w-4 h-4" />
+              )}
+            </button>
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="text-xs text-muted-foreground hover:text-black dark:hover:text-white transition-colors"
+        >
+          Done
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleGenerate} className="flex gap-2">
+      <input
+        type="text"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        placeholder="Token name (optional)"
+        className="flex-1 px-3 py-1.5 text-sm rounded-md border border-black/10 dark:border-white/10 bg-transparent text-black dark:text-white placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-black/20 dark:focus:ring-white/20"
+        disabled={generating}
+        maxLength={50}
+        autoFocus
+      />
+      <button
+        type="submit"
+        disabled={generating}
+        className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-md bg-black dark:bg-white text-white dark:text-black hover:opacity-90 transition-opacity disabled:opacity-50"
+      >
+        {generating ? (
+          <Loader2Icon className="w-3.5 h-3.5 animate-spin" />
+        ) : (
+          <KeyIcon className="w-3.5 h-3.5" />
+        )}
+        Generate
+      </button>
+      <button
+        type="button"
+        onClick={onCancel}
+        disabled={generating}
+        className="px-3 py-1.5 text-sm rounded-md border border-black/10 dark:border-white/10 text-muted-foreground hover:bg-black/5 dark:hover:bg-white/5 transition-colors disabled:opacity-50"
+      >
+        Cancel
+      </button>
+    </form>
+  );
+}
+
+// --- Helpers ---
+
+function formatRelativeDate(dateStr: string): string {
+  const date = new Date(dateStr);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / 60000);
+
+  if (diffMins < 1) return "Just now";
+  if (diffMins < 60) return `${diffMins}m ago`;
+
+  const diffHours = Math.floor(diffMins / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+
+  const diffDays = Math.floor(diffHours / 24);
+  if (diffDays < 30) return `${diffDays}d ago`;
+
+  return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}

--- a/src/lib/supabase/typed-queries.ts
+++ b/src/lib/supabase/typed-queries.ts
@@ -1,0 +1,138 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Team, TeamRole, Profile } from "@/types/database";
+
+/**
+ * Typed wrappers for Supabase PostgREST join queries.
+ *
+ * PostgREST embedded joins return data whose TypeScript shape doesn't match
+ * Supabase's generated types. These helpers centralise the single required
+ * cast so every call-site gets clean, properly-typed results.
+ */
+
+// ──────────────────────────────────────────────
+// Return types
+// ──────────────────────────────────────────────
+
+/** Team enriched with the requesting user's role. */
+export interface TeamWithRole extends Team {
+  role: TeamRole;
+}
+
+/** Team member with their profile information. */
+export interface TeamMemberRow {
+  id: string;
+  team_id: string;
+  user_id: string;
+  role: TeamRole;
+  created_at: string;
+  profile: Profile | null;
+}
+
+/** Pending team invite with the inviter's profile snippet. */
+export interface TeamInviteRow {
+  id: string;
+  team_id: string;
+  email: string;
+  role: TeamRole;
+  status: string;
+  expires_at: string;
+  created_at: string;
+  invited_by: string;
+  inviter: { full_name: string | null; email: string | null } | null;
+}
+
+// ──────────────────────────────────────────────
+// Query helpers
+// ──────────────────────────────────────────────
+
+/**
+ * List every team a user belongs to, together with their role in each.
+ *
+ * Uses: `team_members ← teams` join.
+ */
+export async function getUserTeams(admin: SupabaseClient, userId: string) {
+  const { data: memberships, error } = await admin
+    .from("team_members")
+    .select(
+      "team_id, role, teams(id, name, slug, owner_id, max_members, created_at, updated_at)"
+    )
+    .eq("user_id", userId);
+
+  if (error) return { data: null as null, error };
+
+  const teams: TeamWithRole[] = (memberships ?? []).map((m) => ({
+    // PostgREST returns the joined row as an object, but TS sees it as the
+    // generated (array | null) union — cast once here so callers don't have to.
+    ...(m.teams as unknown as Team),
+    role: m.role as TeamRole,
+  }));
+
+  return { data: teams, error: null };
+}
+
+/**
+ * Fetch members of a team with embedded profile data.
+ *
+ * Uses: `team_members ← profiles` join.
+ */
+export async function getTeamMembers(admin: SupabaseClient, teamId: string) {
+  const { data, error } = await admin
+    .from("team_members")
+    .select(
+      "id, team_id, user_id, role, created_at, profiles(id, email, full_name, avatar_url)"
+    )
+    .eq("team_id", teamId)
+    .order("created_at", { ascending: true });
+
+  if (error) return { data: null as null, error };
+
+  const members: TeamMemberRow[] = (data ?? []).map((m) => ({
+    id: m.id,
+    team_id: m.team_id,
+    user_id: m.user_id,
+    role: m.role as TeamRole,
+    created_at: m.created_at,
+    profile: (m.profiles as unknown as Profile) ?? null,
+  }));
+
+  return { data: members, error: null };
+}
+
+/**
+ * Fetch pending invites for a team, including the inviter's name/email.
+ *
+ * Uses: `team_invites ← profiles` join via `team_invites_invited_by_fkey`.
+ */
+export async function getTeamPendingInvites(
+  admin: SupabaseClient,
+  teamId: string
+) {
+  const { data, error } = await admin
+    .from("team_invites")
+    .select(
+      "id, team_id, email, role, status, expires_at, created_at, invited_by, profiles!team_invites_invited_by_fkey(full_name, email)"
+    )
+    .eq("team_id", teamId)
+    .eq("status", "pending")
+    .order("created_at", { ascending: false });
+
+  if (error) return { data: null as null, error };
+
+  const invites: TeamInviteRow[] = (data ?? []).map((inv) => ({
+    id: inv.id,
+    team_id: inv.team_id,
+    email: inv.email,
+    role: inv.role as TeamRole,
+    status: inv.status,
+    expires_at: inv.expires_at,
+    created_at: inv.created_at,
+    invited_by: inv.invited_by,
+    inviter:
+      (inv.profiles as unknown as {
+        full_name: string | null;
+        email: string | null;
+      }) ?? null,
+  }));
+
+  return { data: invites, error: null };
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -99,3 +99,15 @@ export interface TeamWithMembers extends Team {
   members: TeamMember[];
   invites: TeamInvite[];
 }
+
+// API Sessions
+
+export interface ApiSession {
+  id: string;
+  name: string | null;
+  client_name: string;
+  scope: string;
+  last_used_at: string | null;
+  created_at: string;
+  token_preview: string;
+}


### PR DESCRIPTION
## Summary

- Pro users can generate, view, and revoke API tokens (`uni_xxx`) from the settings page for SSE/MCP clients (v0, Cursor, etc.)
- Adds `create_api_token_direct` and `list_api_sessions` database RPCs (applied via Supabase migration)
- New API routes: `GET/POST /api/auth/tokens` and `DELETE /api/auth/tokens/[sessionId]`
- `ApiTokenSettings` client component follows existing `TeamSettings` pattern
- Error handling improvements to bundles API route
- Typed query helpers added

## Test plan

- [ ] Pro user: visit `/settings`, verify API Tokens section appears after Subscription card
- [ ] Generate a token with a name, verify token is shown once and copyable
- [ ] Refresh page — token appears masked in list with correct name and "last used" time
- [ ] Revoke a token, verify it disappears from the list
- [ ] Use copied token: `curl -H "Authorization: Bearer uni_xxx" https://unicon.sh/api/bundles/me` returns bundles
- [ ] Free user: visit `/settings`, verify API Tokens section is not shown
- [ ] Build passes: `pnpm build --webpack`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new token-issuing and revocation API routes backed by service-role Supabase RPCs, so mistakes could impact token security or access control. UI and logging changes are low risk, but the auth/token surface area is security-sensitive.
> 
> **Overview**
> Adds Pro-user API token management: new `GET/POST /api/auth/tokens` to list/generate tokens and `DELETE /api/auth/tokens/[sessionId]` to revoke via Supabase RPCs, with server-side auth checks and logging.
> 
> Updates `/settings` to fetch token sessions (in parallel with team membership) and render a new `ApiTokenSettings` client card that lists tokens, generates a new one (shown once with copy), and supports revocation.
> 
> Also wraps `GET/POST /api/bundles` in `try/catch` with additional `logger.error` calls, adds a `KeyIcon`, introduces `src/lib/supabase/typed-queries.ts` for typed join query wrappers, and extends database types with `ApiSession`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed1191150a82c979170f3159d8de9b2f29de3946. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->