### PR TITLE
feat: add team logo upload

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -36,6 +36,7 @@ const nextConfig: NextConfig = {
     remotePatterns: [
       { hostname: "avatars.githubusercontent.com" },
       { hostname: "lh3.googleusercontent.com" },
+      { hostname: "ztttwtlglrbxgpydcrdi.supabase.co" },
     ],
   },
   experimental: {

--- a/src/app/api/teams/[teamId]/logo/route.ts
+++ b/src/app/api/teams/[teamId]/logo/route.ts
@@ -1,0 +1,191 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+interface RouteParams {
+  params: Promise<{ teamId: string }>;
+}
+
+const ALLOWED_TYPES = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/gif",
+]);
+const MAX_SIZE = 2 * 1024 * 1024; // 2MB
+
+const EXT_MAP: Record<string, string> = {
+  "image/jpeg": "jpg",
+  "image/png": "png",
+  "image/webp": "webp",
+  "image/gif": "gif",
+};
+
+/**
+ * POST /api/teams/[teamId]/logo — Upload team logo
+ */
+export async function POST(request: Request, { params }: RouteParams) {
+  const { teamId } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const admin = createAdminClient();
+
+  // Verify owner/admin role
+  const { data: membership } = await admin
+    .from("team_members")
+    .select("role")
+    .eq("team_id", teamId)
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  if (!membership || (membership.role !== "owner" && membership.role !== "admin")) {
+    return NextResponse.json(
+      { error: "Only team owners and admins can upload a logo" },
+      { status: 403 }
+    );
+  }
+
+  // Parse form data
+  let formData: FormData;
+  try {
+    formData = await request.formData();
+  } catch {
+    return NextResponse.json({ error: "Invalid form data" }, { status: 400 });
+  }
+
+  const file = formData.get("file");
+  if (!file || !(file instanceof File)) {
+    return NextResponse.json({ error: "No file provided" }, { status: 400 });
+  }
+
+  if (!ALLOWED_TYPES.has(file.type)) {
+    return NextResponse.json(
+      { error: "File must be JPEG, PNG, WebP, or GIF" },
+      { status: 400 }
+    );
+  }
+
+  if (file.size > MAX_SIZE) {
+    return NextResponse.json(
+      { error: "File must be under 2MB" },
+      { status: 400 }
+    );
+  }
+
+  const ext = EXT_MAP[file.type] ?? "png";
+  const filePath = `${teamId}/logo.${ext}`;
+
+  // Remove any existing logo files (handles format changes, e.g. PNG → JPG)
+  const { data: existingFiles } = await admin.storage
+    .from("team-logos")
+    .list(teamId);
+
+  if (existingFiles && existingFiles.length > 0) {
+    const paths = existingFiles.map((f) => `${teamId}/${f.name}`);
+    await admin.storage.from("team-logos").remove(paths);
+  }
+
+  // Upload to storage
+  const { error: uploadError } = await admin.storage
+    .from("team-logos")
+    .upload(filePath, file, {
+      contentType: file.type,
+      upsert: true,
+    });
+
+  if (uploadError) {
+    return NextResponse.json(
+      { error: "Failed to upload logo" },
+      { status: 500 }
+    );
+  }
+
+  // Get the public URL
+  const { data: urlData } = admin.storage
+    .from("team-logos")
+    .getPublicUrl(filePath);
+
+  // Add cache-busting param so browsers pick up new logos
+  const logoUrl = `${urlData.publicUrl}?v=${Date.now()}`;
+
+  // Update teams table
+  const { error: updateError } = await admin
+    .from("teams")
+    .update({ logo_url: logoUrl })
+    .eq("id", teamId);
+
+  if (updateError) {
+    return NextResponse.json(
+      { error: "Failed to update team logo" },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({ logo_url: logoUrl });
+}
+
+/**
+ * DELETE /api/teams/[teamId]/logo — Remove team logo
+ */
+export async function DELETE(_request: Request, { params }: RouteParams) {
+  const { teamId } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const admin = createAdminClient();
+
+  // Verify owner/admin role
+  const { data: membership } = await admin
+    .from("team_members")
+    .select("role")
+    .eq("team_id", teamId)
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  if (!membership || (membership.role !== "owner" && membership.role !== "admin")) {
+    return NextResponse.json(
+      { error: "Only team owners and admins can remove the logo" },
+      { status: 403 }
+    );
+  }
+
+  // List and remove all files in the team's logo folder
+  const { data: files } = await admin.storage
+    .from("team-logos")
+    .list(teamId);
+
+  if (files && files.length > 0) {
+    const paths = files.map((f) => `${teamId}/${f.name}`);
+    await admin.storage.from("team-logos").remove(paths);
+  }
+
+  // Clear logo_url in teams table
+  const { error: updateError } = await admin
+    .from("teams")
+    .update({ logo_url: null })
+    .eq("id", teamId);
+
+  if (updateError) {
+    return NextResponse.json(
+      { error: "Failed to remove team logo" },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/src/components/icons/ui/camera.tsx
+++ b/src/components/icons/ui/camera.tsx
@@ -1,0 +1,22 @@
+import { SVGProps } from "react";
+
+export function CameraIcon({ className, ...props }: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      focusable="false"
+      className={className}
+      {...props}
+    >
+      <path d="M14.5 4h-5L7 7H4a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-3l-2.5-3z" />
+      <circle cx="12" cy="13" r="3" />
+    </svg>
+  );
+}

--- a/src/components/settings/team-settings.tsx
+++ b/src/components/settings/team-settings.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef } from "react";
 import Image from "next/image";
 import { UsersIcon } from "@/components/icons/ui/users";
 import { UserPlusIcon } from "@/components/icons/ui/user-plus";
@@ -8,6 +8,7 @@ import { MailIcon } from "@/components/icons/ui/mail";
 import { Loader2Icon } from "@/components/icons/ui/loader-2";
 import { XIcon } from "@/components/icons/ui/x";
 import { Trash2Icon } from "@/components/icons/ui/trash-2";
+import { CameraIcon } from "@/components/icons/ui/camera";
 import type { TeamWithMembers, TeamMember, TeamInvite } from "@/types/database";
 
 interface TeamSettingsProps {
@@ -223,9 +224,14 @@ function TeamManagement({
 
       {/* Team name */}
       <div className="flex items-center gap-3 mb-5">
-        <div className="w-10 h-10 rounded-lg bg-black/5 dark:bg-white/5 flex items-center justify-center">
-          <UsersIcon className="w-5 h-5 text-muted-foreground" />
-        </div>
+        <TeamLogo
+          team={team}
+          isAdmin={isAdmin}
+          onLogoUpdated={(logoUrl) =>
+            onTeamUpdated({ ...team, logo_url: logoUrl })
+          }
+          setError={setError}
+        />
         <div>
           <p className="text-sm font-medium text-black dark:text-white">
             {team.name}
@@ -280,6 +286,130 @@ function TeamManagement({
 
       {error && (
         <p className="text-xs text-red-600 dark:text-red-400 mt-3">{error}</p>
+      )}
+    </div>
+  );
+}
+
+// --- Team Logo ---
+
+function TeamLogo({
+  team,
+  isAdmin,
+  onLogoUpdated,
+  setError,
+}: {
+  team: TeamWithMembers;
+  isAdmin: boolean;
+  onLogoUpdated: (logoUrl: string | null) => void;
+  setError: (error: string | null) => void;
+}) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [uploading, setUploading] = useState(false);
+
+  async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    // Reset input so the same file can be re-selected
+    e.target.value = "";
+
+    setUploading(true);
+    setError(null);
+
+    try {
+      const formData = new FormData();
+      formData.append("file", file);
+
+      const res = await fetch(`/api/teams/${team.id}/logo`, {
+        method: "POST",
+        body: formData,
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        setError(data.error || "Failed to upload logo");
+        return;
+      }
+
+      onLogoUpdated(data.logo_url);
+    } catch {
+      setError("Failed to upload logo");
+    } finally {
+      setUploading(false);
+    }
+  }
+
+  async function handleRemoveLogo() {
+    setUploading(true);
+    setError(null);
+
+    try {
+      const res = await fetch(`/api/teams/${team.id}/logo`, {
+        method: "DELETE",
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.error || "Failed to remove logo");
+        return;
+      }
+
+      onLogoUpdated(null);
+    } catch {
+      setError("Failed to remove logo");
+    } finally {
+      setUploading(false);
+    }
+  }
+
+  return (
+    <div className="relative group">
+      <div className="w-10 h-10 rounded-lg bg-black/5 dark:bg-white/5 flex items-center justify-center overflow-hidden">
+        {uploading ? (
+          <Loader2Icon className="w-5 h-5 text-muted-foreground animate-spin" />
+        ) : team.logo_url ? (
+          <Image
+            src={team.logo_url}
+            alt={team.name}
+            width={40}
+            height={40}
+            className="w-full h-full object-cover"
+          />
+        ) : (
+          <UsersIcon className="w-5 h-5 text-muted-foreground" />
+        )}
+      </div>
+
+      {isAdmin && !uploading && (
+        <>
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            className="absolute inset-0 flex items-center justify-center rounded-lg bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer"
+            title={team.logo_url ? "Change logo" : "Upload logo"}
+          >
+            <CameraIcon className="w-4 h-4 text-white" />
+          </button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/jpeg,image/png,image/webp,image/gif"
+            onChange={handleFileChange}
+            className="hidden"
+          />
+          {team.logo_url && (
+            <button
+              type="button"
+              onClick={handleRemoveLogo}
+              className="absolute -top-1 -right-1 w-4 h-4 rounded-full bg-red-500 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity"
+              title="Remove logo"
+            >
+              <XIcon className="w-2.5 h-2.5 text-white" />
+            </button>
+          )}
+        </>
       )}
     </div>
   );

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -68,6 +68,7 @@ export interface Team {
   name: string;
   slug: string;
   owner_id: string;
+  logo_url: string | null;
   max_members: number;
   created_at: string;
   updated_at: string;


### PR DESCRIPTION
## Summary
- Add `logo_url` column to `teams` table and `team-logos` storage bucket with RLS policies
- New `POST/DELETE /api/teams/[teamId]/logo` endpoint for upload/removal (admin-only, 2MB limit, JPEG/PNG/WebP/GIF)
- `TeamLogo` component with hover overlay for admins, fallback to `UsersIcon`
- Camera icon component, Supabase storage hostname in `next/image` config

## Test plan
- [ ] Create team → click logo area → upload image → verify it displays
- [ ] Upload a different format (e.g. PNG then JPG) → verify old file is cleaned up
- [ ] Remove logo → verify fallback to UsersIcon
- [ ] Non-admin member should not see upload overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new authenticated, admin-only file upload/delete endpoint backed by Supabase Storage and updates persisted team metadata; main risks are storage/RLS misconfig, validation gaps, and unexpected public URL exposure/caching behavior.
> 
> **Overview**
> Adds team logo support end-to-end: a new `POST`/`DELETE /api/teams/[teamId]/logo` route lets team owners/admins upload (type/size validated) or remove a logo, stores it in the `team-logos` bucket, and updates `teams.logo_url` with a cache-busted public URL.
> 
> Updates the team settings UI to display the logo (or fallback icon) and, for admins, provide hover controls to upload/change/remove using a new `CameraIcon`. Expands `Team` typing with nullable `logo_url` and allows Next `Image` to load from the Supabase storage hostname.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c08fd2a98f17564fbc80186c10097de8b605b3b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->