### PR TITLE
fix(settings): show generated API token after creation

### DIFF
--- a/src/components/settings/api-token-settings.test.tsx
+++ b/src/components/settings/api-token-settings.test.tsx
@@ -1,0 +1,36 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ApiTokenSettings } from "./api-token-settings";
+
+describe("ApiTokenSettings", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("keeps the generated token visible so the user can copy it", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          session_id: "session_123",
+          access_token: "uni_secret_token_1234",
+        }),
+        {
+          status: 201,
+          headers: { "Content-Type": "application/json" },
+        }
+      )
+    );
+
+    render(<ApiTokenSettings initialSessions={[]} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Generate Token" }));
+    fireEvent.click(screen.getByRole("button", { name: "Generate" }));
+
+    expect(
+      await screen.findByText(/token created.*copy it now/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText("uni_secret_token_1234")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Copy token" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Done" })).toBeInTheDocument();
+  });
+});

--- a/src/components/settings/api-token-settings.tsx
+++ b/src/components/settings/api-token-settings.tsx
@@ -65,7 +65,6 @@ export function ApiTokenSettings({ initialSessions }: ApiTokenSettingsProps) {
         <GenerateForm
           onGenerated={(session) => {
             setSessions((prev) => [session, ...prev]);
-            setShowForm(false);
             setError(null);
           }}
           onCancel={() => setShowForm(false)}


### PR DESCRIPTION
## Summary
- keep the token generation form open after successful creation so users can see/copy the new key
- retain existing token list update behavior
- add a regression test for generated token visibility and copy controls

## Testing
- pnpm test src/components/settings/api-token-settings.test.tsx
- pnpm test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-state change plus a new test; no backend/auth logic changes, with minimal risk beyond token-generation UX flow.
> 
> **Overview**
> Fixes API token generation UX by **keeping the generation form open after a successful create**, so the freshly generated token remains visible for copying (while still prepending the new session to the token list).
> 
> Adds a Vitest regression test for `ApiTokenSettings` that mocks token creation and asserts the success message, raw token text, and `Copy token`/`Done` controls are rendered after generating.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e0a4fe15a3a6c9934792b58dc15f9ab74b39804. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->