### PR TITLE
fix: enforce fail-closed auth for admin API routes

### DIFF
--- a/src/__tests__/admin-auth.test.ts
+++ b/src/__tests__/admin-auth.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { requireAdminAuth } from "@/lib/auth/admin";
+
+describe("requireAdminAuth", () => {
+  const originalAdminSecret = process.env.ADMIN_SECRET;
+
+  afterEach(() => {
+    if (originalAdminSecret === undefined) {
+      delete process.env.ADMIN_SECRET;
+    } else {
+      process.env.ADMIN_SECRET = originalAdminSecret;
+    }
+  });
+
+  it("returns 503 when ADMIN_SECRET is not configured", async () => {
+    delete process.env.ADMIN_SECRET;
+
+    const request = new Request("https://example.com/api/admin");
+    const response = requireAdminAuth(request);
+
+    expect(response).not.toBeNull();
+    expect(response?.status).toBe(503);
+    await expect(response?.json()).resolves.toEqual({
+      error: "Admin authentication is not configured",
+    });
+  });
+
+  it("returns 401 when authorization header is missing", () => {
+    process.env.ADMIN_SECRET = "test-secret";
+
+    const request = new Request("https://example.com/api/admin");
+    const response = requireAdminAuth(request);
+
+    expect(response).not.toBeNull();
+    expect(response?.status).toBe(401);
+  });
+
+  it("returns 401 when bearer token is invalid", () => {
+    process.env.ADMIN_SECRET = "test-secret";
+
+    const request = new Request("https://example.com/api/admin", {
+      headers: { Authorization: "Bearer wrong-secret" },
+    });
+    const response = requireAdminAuth(request);
+
+    expect(response).not.toBeNull();
+    expect(response?.status).toBe(401);
+  });
+
+  it("returns null when bearer token matches ADMIN_SECRET", () => {
+    process.env.ADMIN_SECRET = "test-secret";
+
+    const request = new Request("https://example.com/api/admin", {
+      headers: { Authorization: "Bearer test-secret" },
+    });
+    const response = requireAdminAuth(request);
+
+    expect(response).toBeNull();
+  });
+});

--- a/src/app/api/admin/analytics/route.ts
+++ b/src/app/api/admin/analytics/route.ts
@@ -1,19 +1,16 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSearchStats } from "@/lib/analytics";
 import { logger } from "@/lib/logger";
+import { requireAdminAuth } from "@/lib/auth/admin";
 
 /**
  * Get search analytics statistics
  * GET /api/admin/analytics?days=7
  */
 export async function GET(request: NextRequest) {
-  // Check for admin secret if configured
-  const adminSecret = process.env.ADMIN_SECRET;
-  if (adminSecret) {
-    const authHeader = request.headers.get("authorization");
-    if (!authHeader || authHeader !== `Bearer ${adminSecret}`) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+  const authErrorResponse = requireAdminAuth(request);
+  if (authErrorResponse) {
+    return authErrorResponse;
   }
 
   const { searchParams } = new URL(request.url);

--- a/src/app/api/admin/generate-embeddings/route.ts
+++ b/src/app/api/admin/generate-embeddings/route.ts
@@ -4,6 +4,7 @@ import { icons } from "@/lib/schema";
 import { getEmbeddings, embeddingToBlob } from "@/lib/ai";
 import { sql, isNull } from "drizzle-orm";
 import { logger } from "@/lib/logger";
+import { requireAdminAuth } from "@/lib/auth/admin";
 
 const BATCH_SIZE = 100;
 const MAX_BATCHES_PER_REQUEST = 10; // Process up to 1000 icons per request
@@ -19,13 +20,9 @@ const MAX_BATCHES_PER_REQUEST = 10; // Process up to 1000 icons per request
  *   - batchSize: Number of icons per batch (default: 100)
  */
 export async function POST(request: NextRequest) {
-  // Verify admin secret in production
-  const adminSecret = process.env.ADMIN_SECRET;
-  if (adminSecret) {
-    const authHeader = request.headers.get("authorization");
-    if (authHeader !== `Bearer ${adminSecret}`) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+  const authErrorResponse = requireAdminAuth(request);
+  if (authErrorResponse) {
+    return authErrorResponse;
   }
 
   try {
@@ -99,7 +96,12 @@ export async function POST(request: NextRequest) {
  * 
  * Get embedding statistics.
  */
-export async function GET() {
+export async function GET(request: NextRequest) {
+  const authErrorResponse = requireAdminAuth(request);
+  if (authErrorResponse) {
+    return authErrorResponse;
+  }
+
   try {
     const stats = await db
       .select({

--- a/src/app/api/admin/warm-cache/route.ts
+++ b/src/app/api/admin/warm-cache/route.ts
@@ -4,6 +4,7 @@ import { db } from "@/lib/db";
 import { sql } from "drizzle-orm";
 import type { IconData } from "@/types/icon";
 import { logger } from "@/lib/logger";
+import { requireAdminAuth } from "@/lib/auth/admin";
 
 /**
  * Popular search queries to pre-warm the cache.
@@ -42,13 +43,9 @@ const POPULAR_QUERIES = [
  *   - queries: Comma-separated list of custom queries (optional)
  */
 export async function POST(request: NextRequest) {
-  // Verify admin secret in production
-  const adminSecret = process.env.ADMIN_SECRET;
-  if (adminSecret) {
-    const authHeader = request.headers.get("authorization");
-    if (authHeader !== `Bearer ${adminSecret}`) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+  const authErrorResponse = requireAdminAuth(request);
+  if (authErrorResponse) {
+    return authErrorResponse;
   }
 
   try {
@@ -158,7 +155,12 @@ export async function POST(request: NextRequest) {
  *
  * Get list of popular queries that will be cached.
  */
-export async function GET() {
+export async function GET(request: NextRequest) {
+  const authErrorResponse = requireAdminAuth(request);
+  if (authErrorResponse) {
+    return authErrorResponse;
+  }
+
   return NextResponse.json({
     popularQueries: POPULAR_QUERIES,
     count: POPULAR_QUERIES.length,

--- a/src/lib/auth/admin.ts
+++ b/src/lib/auth/admin.ts
@@ -1,0 +1,40 @@
+import { timingSafeEqual } from "crypto";
+import { NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
+
+/**
+ * Require ADMIN_SECRET-backed Bearer auth for admin routes.
+ * Returns an error response when auth fails, otherwise null.
+ */
+export function requireAdminAuth(request: Request): NextResponse | null {
+  const adminSecret = process.env.ADMIN_SECRET;
+
+  // Fail closed if admin auth is not configured.
+  if (!adminSecret) {
+    logger.error("ADMIN_SECRET is not configured for admin route access");
+    return NextResponse.json(
+      { error: "Admin authentication is not configured" },
+      { status: 503 }
+    );
+  }
+
+  const authHeader = request.headers.get("authorization");
+  const token = authHeader?.match(/^Bearer\s+(.+)$/i)?.[1];
+
+  if (!token) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const providedTokenBuffer = Buffer.from(token, "utf8");
+  const adminSecretBuffer = Buffer.from(adminSecret, "utf8");
+
+  const isValid =
+    providedTokenBuffer.length === adminSecretBuffer.length &&
+    timingSafeEqual(providedTokenBuffer, adminSecretBuffer);
+
+  if (!isValid) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- add a shared `requireAdminAuth()` guard for admin route authorization
- fail closed when `ADMIN_SECRET` is missing (returns 503 instead of allowing access)
- require admin auth on all admin route methods, including previously unprotected `GET` handlers

## Changes
- new guard: `src/lib/auth/admin.ts`
- protected `GET /api/admin/analytics`
- protected `GET` + `POST /api/admin/generate-embeddings`
- protected `GET` + `POST /api/admin/warm-cache`
- add focused tests for the admin guard behavior

## Validation
- `pnpm -s lint`
- `pnpm -s typecheck`
- `pnpm -s test`

Closes #39
Closes #40
Closes #41

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authorization behavior for admin routes and will block access if `ADMIN_SECRET` is misconfigured, potentially impacting operations. The new timing-safe token check and broader enforcement reduce security risk but increase deployment/config sensitivity.
> 
> **Overview**
> **Enforces fail-closed authentication for admin API routes.** Admin endpoints now share a new `requireAdminAuth()` guard that requires a `Bearer` token matching `ADMIN_SECRET`, uses timing-safe comparison, and returns `503` when `ADMIN_SECRET` is missing.
> 
> All relevant admin handlers (`analytics`, `generate-embeddings`, `warm-cache`) are updated to use this guard (including previously unprotected `GET` methods), and a new Vitest suite covers the expected `503`/`401`/success behaviors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49c3525a01dc20398baffd3caa70169e03f07ff7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->