### PR TITLE
fix: make stripe webhook updates retry-safe and status-aware

### DIFF
--- a/src/__tests__/stripe-webhook.test.ts
+++ b/src/__tests__/stripe-webhook.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { mapStripeSubscriptionStatus } from "@/lib/stripe-webhook";
+
+describe("mapStripeSubscriptionStatus", () => {
+  it("maps active and trialing to active", () => {
+    expect(mapStripeSubscriptionStatus("active")).toBe("active");
+    expect(mapStripeSubscriptionStatus("trialing")).toBe("active");
+  });
+
+  it("maps billing-problem states to past_due", () => {
+    expect(mapStripeSubscriptionStatus("past_due")).toBe("past_due");
+    expect(mapStripeSubscriptionStatus("unpaid")).toBe("past_due");
+    expect(mapStripeSubscriptionStatus("incomplete")).toBe("past_due");
+    expect(mapStripeSubscriptionStatus("paused")).toBe("past_due");
+  });
+
+  it("maps terminal states to canceled", () => {
+    expect(mapStripeSubscriptionStatus("canceled")).toBe("canceled");
+    expect(mapStripeSubscriptionStatus("incomplete_expired")).toBe("canceled");
+  });
+});

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -3,6 +3,7 @@ import { headers } from "next/headers";
 import { stripe } from "@/lib/stripe";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { logger } from "@/lib/logger";
+import { mapStripeSubscriptionStatus } from "@/lib/stripe-webhook";
 import type Stripe from "stripe";
 
 const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET!;
@@ -99,7 +100,9 @@ export async function POST(request: Request) {
           .or(`current_period_end.is.null,current_period_end.lt.${new Date(periodEnd * 1000).toISOString()}`);
 
         if (updateError) {
-          logger.error(`Failed to update subscription for user ${userId}:`, updateError);
+          throw new Error(
+            `Failed to update subscription for user ${userId}: ${updateError.message}`
+          );
         } else {
           logger.log(`Subscription activated for user ${userId}`);
         }
@@ -111,8 +114,7 @@ export async function POST(request: Request) {
         const periodEnd = (subscription as unknown as { current_period_end: number }).current_period_end;
         const periodEndDate = new Date(periodEnd * 1000).toISOString();
 
-        const newStatus = subscription.status === "active" ? "active" :
-                         subscription.status === "past_due" ? "past_due" : "canceled";
+        const newStatus = mapStripeSubscriptionStatus(subscription.status);
 
         // Update by subscription ID with optimistic locking on period end
         const { error: updateError } = await supabase
@@ -126,7 +128,9 @@ export async function POST(request: Request) {
           .or(`current_period_end.is.null,current_period_end.lte.${periodEndDate}`);
 
         if (updateError) {
-          logger.error(`Failed to update subscription ${subscription.id}:`, updateError);
+          throw new Error(
+            `Failed to update subscription ${subscription.id}: ${updateError.message}`
+          );
         } else {
           logger.log(`Subscription ${subscription.id} updated to ${newStatus}`);
         }
@@ -148,7 +152,9 @@ export async function POST(request: Request) {
           .eq("provider_subscription_id", subscription.id);
 
         if (updateError) {
-          logger.error(`Failed to cancel subscription ${subscription.id}:`, updateError);
+          throw new Error(
+            `Failed to cancel subscription ${subscription.id}: ${updateError.message}`
+          );
         } else {
           logger.log(`Subscription canceled for subscription ${subscription.id}`);
         }

--- a/src/lib/stripe-webhook.ts
+++ b/src/lib/stripe-webhook.ts
@@ -1,0 +1,31 @@
+import type Stripe from "stripe";
+
+export type LocalSubscriptionStatus = "active" | "past_due" | "canceled";
+
+/**
+ * Map Stripe subscription statuses to local subscription statuses.
+ *
+ * We intentionally avoid collapsing `trialing` and `incomplete` into `canceled`
+ * to prevent accidental premature downgrades.
+ */
+export function mapStripeSubscriptionStatus(
+  status: Stripe.Subscription.Status
+): LocalSubscriptionStatus {
+  switch (status) {
+    case "active":
+    case "trialing":
+      return "active";
+    case "past_due":
+    case "unpaid":
+    case "incomplete":
+    case "paused":
+      return "past_due";
+    case "canceled":
+    case "incomplete_expired":
+      return "canceled";
+    default: {
+      const _exhaustiveCheck: never = status;
+      return _exhaustiveCheck;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- prevent webhook events from being marked processed when subscription DB updates fail
- fix status mapping so Stripe `trialing` and `incomplete` are not collapsed to `canceled`
- add tested, centralized Stripe-to-local subscription status mapping

## Changes
- `src/app/api/webhooks/stripe/route.ts`
  - throw on subscription update failures in handled Stripe events
  - this returns 500 so Stripe retries the event instead of silently dropping it
  - use centralized mapping for `customer.subscription.updated`
- `src/lib/stripe-webhook.ts`
  - add `mapStripeSubscriptionStatus()`
- `src/__tests__/stripe-webhook.test.ts`
  - add status mapping tests for active/trialing, billing-problem states, and terminal states

## Validation
- `pnpm -s lint`
- `pnpm -s typecheck`
- `pnpm -s test`

Closes #42
Closes #43

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes webhook error handling and subscription status mapping, which can affect billing state transitions and retry behavior if the mapping/throws are incorrect.
> 
> **Overview**
> Makes Stripe webhook processing **retry-safe** by throwing when Supabase subscription updates fail (for `checkout.session.completed`, `customer.subscription.updated`, and `customer.subscription.deleted`), causing a 500 so Stripe will retry instead of marking the event processed.
> 
> Introduces a centralized `mapStripeSubscriptionStatus` helper and uses it for `customer.subscription.updated`, ensuring Stripe states like `trialing` map to local `active` and `incomplete` maps to `past_due` (avoiding premature `canceled`). Adds Vitest coverage for the new status mapping.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6839a2106d08502c653acfe5920730f6636f67e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->