### PR TITLE
fix: prevent x-forwarded-for spoofing in public rate limits

### DIFF
--- a/src/__tests__/request-ip.test.ts
+++ b/src/__tests__/request-ip.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { getTrustedClientIp } from "@/lib/request-ip";
+
+describe("getTrustedClientIp", () => {
+  it("uses x-real-ip when present", () => {
+    const request = new Request("https://example.com", {
+      headers: {
+        "x-real-ip": "203.0.113.10",
+        "x-forwarded-for": "198.51.100.77",
+      },
+    });
+
+    expect(getTrustedClientIp(request)).toBe("203.0.113.10");
+  });
+
+  it("does not trust x-forwarded-for when x-real-ip is missing", () => {
+    const request = new Request("https://example.com", {
+      headers: {
+        "x-forwarded-for": "198.51.100.77",
+      },
+    });
+
+    expect(getTrustedClientIp(request)).toBe("unknown");
+  });
+});

--- a/src/app/api/icons/route.ts
+++ b/src/app/api/icons/route.ts
@@ -9,6 +9,7 @@ import { logSearch } from "@/lib/analytics";
 import { checkPublicRateLimit, getRateLimitHeaders } from "@/lib/rate-limit";
 import { waitUntil } from "@vercel/functions";
 import { parsePagination } from "@/lib/api/pagination";
+import { getTrustedClientIp } from "@/lib/request-ip";
 
 const CORS_HEADERS = {
   "Access-Control-Allow-Origin": "*",
@@ -42,11 +43,8 @@ interface VectorSearchRow {
 }
 
 export async function GET(request: NextRequest) {
-  // Rate limit by IP (x-real-ip is set reliably by Vercel and cannot be spoofed)
-  const ip =
-    request.headers.get("x-real-ip") ??
-    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
-    "unknown";
+  // Rate limit by trusted platform IP only.
+  const ip = getTrustedClientIp(request);
   const rateLimit = await checkPublicRateLimit(ip);
 
   if (!rateLimit.success) {

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -14,6 +14,7 @@ import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/
 import { logger } from "@/lib/logger";
 import { validateApiToken } from "@/lib/auth/api-token";
 import { checkPublicRateLimit, getRateLimitHeaders } from "@/lib/rate-limit";
+import { getTrustedClientIp } from "@/lib/request-ip";
 import {
   type AuthContext,
   registerSearchTools,
@@ -159,11 +160,8 @@ async function handleMcpRequest(request: Request, method: string): Promise<Respo
  * POST /api/mcp - Handle MCP requests
  */
 export async function POST(request: Request) {
-  // Rate limit by IP (x-real-ip is set reliably by Vercel and cannot be spoofed)
-  const ip =
-    request.headers.get("x-real-ip") ??
-    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
-    "unknown";
+  // Rate limit by trusted platform IP only.
+  const ip = getTrustedClientIp(request);
   const rateLimit = await checkPublicRateLimit(ip);
 
   if (!rateLimit.success) {

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -8,6 +8,7 @@ import type { IconData } from "@/types/icon";
 import { logger } from "@/lib/logger";
 import { checkPublicRateLimit, getRateLimitHeaders } from "@/lib/rate-limit";
 import { parsePagination } from "@/lib/api/pagination";
+import { getTrustedClientIp } from "@/lib/request-ip";
 
 interface SearchResult extends IconData {
   score: number;
@@ -67,11 +68,8 @@ const MAX_LIMIT = 320;
  * with optional AI fallback for complex queries.
  */
 export async function POST(request: NextRequest) {
-  // Rate limit by IP (x-real-ip is set reliably by Vercel and cannot be spoofed)
-  const ip =
-    request.headers.get("x-real-ip") ??
-    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
-    "unknown";
+  // Rate limit by trusted platform IP only.
+  const ip = getTrustedClientIp(request);
   const rateLimit = await checkPublicRateLimit(ip);
 
   if (!rateLimit.success) {

--- a/src/lib/request-ip.ts
+++ b/src/lib/request-ip.ts
@@ -1,0 +1,10 @@
+import { ipAddress } from "@vercel/functions";
+
+/**
+ * Resolve a trusted client IP for rate-limiting.
+ *
+ * Intentionally does not use `x-forwarded-for`, which can be spoofed by clients.
+ */
+export function getTrustedClientIp(request: Request): string {
+  return ipAddress(request) ?? "unknown";
+}


### PR DESCRIPTION
## Summary
- remove `x-forwarded-for` fallback from public rate-limit key extraction
- use only trusted platform IP extraction (`x-real-ip` via Vercel helper)
- add tests that verify spoofed `x-forwarded-for` is ignored

## Changes
- add `src/lib/request-ip.ts`
- update public endpoints to use trusted IP helper:
  - `src/app/api/icons/route.ts`
  - `src/app/api/search/route.ts`
  - `src/app/api/mcp/route.ts`
- add tests: `src/__tests__/request-ip.test.ts`

## Validation
- `pnpm -s lint`
- `pnpm -s typecheck`
- `pnpm -s test`

Closes #38

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how public rate limits derive the client identifier, which can affect throttling behavior and potentially group more requests under `unknown` if the platform IP cannot be resolved. Security impact is positive (reduces header spoofing), but behavior changes apply across multiple public endpoints.
> 
> **Overview**
> Public rate limiting now derives its key from a new `getTrustedClientIp` helper that uses Vercel’s trusted `ipAddress()` resolution and **intentionally ignores** `x-forwarded-for` to prevent spoofing.
> 
> Updates `/api/icons`, `/api/search`, and `/api/mcp` to use this helper instead of manually parsing headers, and adds unit tests asserting `x-real-ip` is honored while `x-forwarded-for` alone results in `unknown`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97fcc781693e410407bbf82aadffb8f4cba5a945. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->