### PR TITLE
fix: prevent team invite acceptance race

### DIFF
--- a/src/app/api/invites/[token]/route.ts
+++ b/src/app/api/invites/[token]/route.ts
@@ -6,6 +6,13 @@ interface RouteParams {
   params: Promise<{ token: string }>;
 }
 
+interface AcceptInviteResult {
+  success: boolean;
+  error: string | null;
+  team_id: string | null;
+  team_name: string | null;
+}
+
 /**
  * POST /api/invites/[token] — Accept an invite (authenticated user)
  */
@@ -22,89 +29,43 @@ export async function POST(_request: Request, { params }: RouteParams) {
   }
 
   const admin = createAdminClient();
-
-  // Find the invite
-  const { data: invite, error: inviteError } = await admin
-    .from("team_invites")
-    .select("*, teams(name, max_members)")
-    .eq("token", token)
-    .eq("status", "pending")
-    .single();
-
-  if (inviteError || !invite) {
-    return NextResponse.json(
-      { error: "Invite not found or already used" },
-      { status: 404 }
-    );
-  }
-
-  // Check expiration
-  if (new Date(invite.expires_at) < new Date()) {
-    await admin
-      .from("team_invites")
-      .update({ status: "expired" })
-      .eq("id", invite.id);
-
-    return NextResponse.json({ error: "This invite has expired" }, { status: 410 });
-  }
-
-  // Check team capacity
-  const { count } = await admin
-    .from("team_members")
-    .select("id", { count: "exact", head: true })
-    .eq("team_id", invite.team_id);
-
-  const team = invite.teams as { name: string; max_members: number };
-  if ((count ?? 0) >= team.max_members) {
-    return NextResponse.json(
-      { error: "Team is at maximum capacity" },
-      { status: 409 }
-    );
-  }
-
-  // Check if user is already a member
-  const { data: existingMember } = await admin
-    .from("team_members")
-    .select("id")
-    .eq("team_id", invite.team_id)
-    .eq("user_id", user.id)
-    .maybeSingle();
-
-  if (existingMember) {
-    // Mark invite as accepted even if already a member
-    await admin
-      .from("team_invites")
-      .update({ status: "accepted" })
-      .eq("id", invite.id);
-
-    return NextResponse.json(
-      { error: "You're already a member of this team" },
-      { status: 409 }
-    );
-  }
-
-  // Create membership
-  const { error: memberError } = await admin.from("team_members").insert({
-    team_id: invite.team_id,
-    user_id: user.id,
-    role: invite.role === "owner" ? "member" : invite.role, // prevent invite to owner role
+  const { data, error } = await admin.rpc("accept_team_invite_atomic", {
+    p_token: token,
+    p_user_id: user.id,
   });
 
-  if (memberError) {
-    return NextResponse.json({ error: memberError.message }, { status: 500 });
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
   }
 
-  // Mark invite as accepted
-  await admin
-    .from("team_invites")
-    .update({ status: "accepted" })
-    .eq("id", invite.id);
+  const result = data?.[0] as AcceptInviteResult | undefined;
+  if (!result) {
+    return NextResponse.json(
+      { error: "Failed to accept invite" },
+      { status: 500 }
+    );
+  }
+
+  if (!result.success) {
+    const message = result.error ?? "Failed to accept invite";
+    const status = mapInviteErrorToStatus(message);
+    return NextResponse.json({ error: message }, { status });
+  }
 
   return NextResponse.json({
     success: true,
     team: {
-      id: invite.team_id,
-      name: team.name,
+      id: result.team_id,
+      name: result.team_name,
     },
   });
+}
+
+function mapInviteErrorToStatus(error: string): number {
+  if (error === "Invite not found or already used") return 404;
+  if (error === "This invite has expired") return 410;
+  if (error === "Team is at maximum capacity") return 409;
+  if (error === "You're already a member of this team") return 409;
+  if (error === "Team not found") return 404;
+  return 400;
 }

--- a/supabase/migrations/20260216000000_accept_team_invite_atomic.sql
+++ b/supabase/migrations/20260216000000_accept_team_invite_atomic.sql
@@ -1,0 +1,102 @@
+-- Atomic team invite acceptance with capacity enforcement
+-- Prevents concurrent invite acceptance from exceeding teams.max_members
+
+CREATE OR REPLACE FUNCTION public.accept_team_invite_atomic(
+  p_token TEXT,
+  p_user_id UUID
+)
+RETURNS TABLE (
+  success BOOLEAN,
+  error TEXT,
+  team_id UUID,
+  team_name TEXT
+) AS $$
+DECLARE
+  v_invite public.team_invites%ROWTYPE;
+  v_team public.teams%ROWTYPE;
+  v_member_count INTEGER;
+BEGIN
+  -- Lock invite row so status transitions are serialized per token
+  SELECT * INTO v_invite
+  FROM public.team_invites
+  WHERE token = p_token
+    AND status = 'pending'
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT FALSE, 'Invite not found or already used'::TEXT, NULL::UUID, NULL::TEXT;
+    RETURN;
+  END IF;
+
+  -- Lock team row so member count + insert is serialized per team
+  SELECT * INTO v_team
+  FROM public.teams
+  WHERE id = v_invite.team_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT FALSE, 'Team not found'::TEXT, NULL::UUID, NULL::TEXT;
+    RETURN;
+  END IF;
+
+  IF v_invite.expires_at < NOW() THEN
+    UPDATE public.team_invites
+    SET status = 'expired'
+    WHERE id = v_invite.id;
+
+    RETURN QUERY SELECT FALSE, 'This invite has expired'::TEXT, NULL::UUID, NULL::TEXT;
+    RETURN;
+  END IF;
+
+  -- If user is already a member, mirror existing behavior:
+  -- mark invite accepted and return a conflict message.
+  IF EXISTS (
+    SELECT 1
+    FROM public.team_members
+    WHERE team_id = v_invite.team_id
+      AND user_id = p_user_id
+  ) THEN
+    UPDATE public.team_invites
+    SET status = 'accepted'
+    WHERE id = v_invite.id;
+
+    RETURN QUERY SELECT FALSE, 'You''re already a member of this team'::TEXT, v_team.id, v_team.name;
+    RETURN;
+  END IF;
+
+  SELECT COUNT(*)::INTEGER INTO v_member_count
+  FROM public.team_members
+  WHERE team_id = v_invite.team_id;
+
+  IF v_member_count >= v_team.max_members THEN
+    RETURN QUERY SELECT FALSE, 'Team is at maximum capacity'::TEXT, v_team.id, v_team.name;
+    RETURN;
+  END IF;
+
+  BEGIN
+    INSERT INTO public.team_members (team_id, user_id, role)
+    VALUES (
+      v_invite.team_id,
+      p_user_id,
+      CASE
+        WHEN v_invite.role = 'owner' THEN 'member'::public.team_role
+        ELSE v_invite.role
+      END
+    );
+  EXCEPTION
+    WHEN unique_violation THEN
+      UPDATE public.team_invites
+      SET status = 'accepted'
+      WHERE id = v_invite.id;
+
+      RETURN QUERY SELECT FALSE, 'You''re already a member of this team'::TEXT, v_team.id, v_team.name;
+      RETURN;
+  END;
+
+  UPDATE public.team_invites
+  SET status = 'accepted'
+  WHERE id = v_invite.id;
+
+  RETURN QUERY SELECT TRUE, NULL::TEXT, v_team.id, v_team.name;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Summary
- replace multi-step invite acceptance logic with a single atomic RPC call
- add accept_team_invite_atomic migration to lock invite/team rows and enforce capacity safely
- map structured RPC errors to stable HTTP status codes in the invite acceptance endpoint

## Testing
- pnpm -s lint
- pnpm -s typecheck
- pnpm -s test

Closes #44

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes both API behavior and database-side invite acceptance logic (row locking, inserts, status transitions), which could impact invite flows if edge cases or error mapping differ from prior behavior.
> 
> **Overview**
> Invite acceptance (`POST /api/invites/[token]`) now uses a single RPC call (`accept_team_invite_atomic`) instead of multiple sequential queries/updates, reducing race conditions around membership creation and max-member checks.
> 
> Adds a Supabase migration defining `accept_team_invite_atomic`, which locks the invite and team rows, validates pending/expiry/team existence, enforces `teams.max_members`, inserts membership (downgrading `owner` to `member`), and marks the invite accepted, while the API maps returned error messages to stable HTTP status codes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22995140008ec35fb133959bbeebb76575c1425a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->