### PR TITLE
fix: make API hasMore pagination metadata accurate

### DIFF
--- a/src/__tests__/pagination.test.ts
+++ b/src/__tests__/pagination.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parsePagination } from "@/lib/api/pagination";
+import { parsePagination, sliceForPagination } from "@/lib/api/pagination";
 
 describe("parsePagination", () => {
   it("uses defaults when limit and offset are omitted", () => {
@@ -55,5 +55,17 @@ describe("parsePagination", () => {
     });
 
     expect(result).toEqual({ error: "offset must be greater than or equal to 0" });
+  });
+});
+
+describe("sliceForPagination", () => {
+  it("reports hasMore=false when rows do not exceed limit", () => {
+    const result = sliceForPagination([1, 2, 3], 3);
+    expect(result).toEqual({ items: [1, 2, 3], hasMore: false });
+  });
+
+  it("reports hasMore=true and trims extra row when rows exceed limit", () => {
+    const result = sliceForPagination([1, 2, 3, 4], 3);
+    expect(result).toEqual({ items: [1, 2, 3], hasMore: true });
   });
 });

--- a/src/app/api/icons/route.ts
+++ b/src/app/api/icons/route.ts
@@ -8,7 +8,7 @@ import { logger } from "@/lib/logger";
 import { logSearch } from "@/lib/analytics";
 import { checkPublicRateLimit, getRateLimitHeaders } from "@/lib/rate-limit";
 import { waitUntil } from "@vercel/functions";
-import { parsePagination } from "@/lib/api/pagination";
+import { parsePagination, sliceForPagination } from "@/lib/api/pagination";
 import { getTrustedClientIp } from "@/lib/request-ip";
 
 const CORS_HEADERS = {
@@ -114,7 +114,7 @@ export async function GET(request: NextRequest) {
       return NextResponse.json(
         {
           icons: aiResults.icons,
-          hasMore: aiResults.icons.length === limit,
+          hasMore: aiResults.hasMore,
           searchType: aiResults.searchType,
           expandedQuery: aiResults.expandedQuery,
         },
@@ -147,7 +147,11 @@ export async function GET(request: NextRequest) {
     if (sourceParam && sourceParam !== "all") params.sourceId = sourceParam;
     if (categoryParam && categoryParam !== "all") params.category = categoryParam;
 
-    const icons = await searchIcons(params);
+    const iconRows = await searchIcons({
+      ...params,
+      limit: limit + 1,
+    });
+    const { items: icons, hasMore } = sliceForPagination(iconRows, limit);
 
     // Log analytics for text search (fire-and-forget, waitUntil ensures completion after response)
     if (queryParam) {
@@ -162,7 +166,7 @@ export async function GET(request: NextRequest) {
     }
 
     return NextResponse.json(
-      { icons, hasMore: icons.length === limit, searchType: "text" },
+      { icons, hasMore, searchType: "text" },
       {
         headers: {
           ...CORS_HEADERS,
@@ -194,7 +198,7 @@ async function aiSemanticSearch(
   sourceId: string | undefined,
   limit: number,
   offset: number
-): Promise<{ icons: IconData[]; searchType: string; expandedQuery?: string; cacheHit: boolean }> {
+): Promise<{ icons: IconData[]; hasMore: boolean; searchType: string; expandedQuery?: string; cacheHit: boolean }> {
   // Check cache first
   const cacheKey = generateSearchCacheKey({
     query,
@@ -202,7 +206,7 @@ async function aiSemanticSearch(
     limit,
     offset,
   });
-  const cached = getCachedSearchResults<{ icons: IconData[]; searchType: string; expandedQuery?: string }>(cacheKey);
+  const cached = getCachedSearchResults<{ icons: IconData[]; hasMore: boolean; searchType: string; expandedQuery?: string }>(cacheKey);
   if (cached) {
     logger.log(`Cache hit for search: "${query}"`);
     return { ...cached, cacheHit: true };
@@ -246,12 +250,13 @@ async function aiSemanticSearch(
     // Fall back to text search if embedding fails
     const searchParams: { query: string; sourceId?: string; limit: number; offset: number } = {
       query,
-      limit,
+      limit: limit + 1,
       offset
     };
     if (sourceId) searchParams.sourceId = sourceId;
-    const textResults = await searchIcons(searchParams);
-    return { icons: textResults, searchType: "text", cacheHit: false };
+    const textRows = await searchIcons(searchParams);
+    const { items: icons, hasMore } = sliceForPagination(textRows, limit);
+    return { icons, hasMore, searchType: "text", cacheHit: false };
   }
 
   // Convert embedding to Turso vector format
@@ -270,7 +275,7 @@ async function aiSemanticSearch(
         FROM icons
         WHERE embedding IS NOT NULL AND source_id = ${sourceId}
         ORDER BY distance ASC
-        LIMIT ${limit} OFFSET ${offset}
+        LIMIT ${limit + 1} OFFSET ${offset}
       `)
     : await db.all(sql`
         SELECT
@@ -282,11 +287,11 @@ async function aiSemanticSearch(
         FROM icons
         WHERE embedding IS NOT NULL
         ORDER BY distance ASC
-        LIMIT ${limit} OFFSET ${offset}
+        LIMIT ${limit + 1} OFFSET ${offset}
       `)) as VectorSearchRow[];
 
   // Convert to IconData
-  const icons: IconData[] = semanticResults.map((row) => {
+  const iconRows: IconData[] = semanticResults.map((row) => {
     let tags: string[];
     try {
       tags = typeof row.tags === "string" ? JSON.parse(row.tags) : (row.tags ?? []);
@@ -319,9 +324,11 @@ async function aiSemanticSearch(
       brandColor: row.brandColor as string | null,
     };
   });
+  const { items: icons, hasMore } = sliceForPagination(iconRows, limit);
 
-  const result: { icons: IconData[]; searchType: string; expandedQuery?: string; cacheHit: boolean } = {
+  const result: { icons: IconData[]; hasMore: boolean; searchType: string; expandedQuery?: string; cacheHit: boolean } = {
     icons,
+    hasMore,
     searchType: "semantic",
     cacheHit: false,
   };

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -7,7 +7,7 @@ import { sql, eq, or, like, asc } from "drizzle-orm";
 import type { IconData } from "@/types/icon";
 import { logger } from "@/lib/logger";
 import { checkPublicRateLimit, getRateLimitHeaders } from "@/lib/rate-limit";
-import { parsePagination } from "@/lib/api/pagination";
+import { parsePagination, sliceForPagination } from "@/lib/api/pagination";
 import { getTrustedClientIp } from "@/lib/request-ip";
 
 interface SearchResult extends IconData {
@@ -130,12 +130,12 @@ export async function POST(request: NextRequest) {
 
     // For very short queries, use text search
     if (trimmedQuery.length < 3) {
-      const results = await textSearch(trimmedQuery, sourceFilter, limit, offset);
+      const textResult = await textSearch(trimmedQuery, sourceFilter, limit, offset);
       return NextResponse.json(
         {
-          results,
+          results: textResult.results,
           searchType: "text",
-          hasMore: results.length === limit,
+          hasMore: textResult.hasMore,
         },
         {
           headers: {
@@ -170,7 +170,13 @@ export async function POST(request: NextRequest) {
         }
       }
 
-      const results = await hybridSearch(trimmedQuery, searchQuery, sourceFilter, limit, offset);
+      const hybridResult = await hybridSearch(
+        trimmedQuery,
+        searchQuery,
+        sourceFilter,
+        limit,
+        offset
+      );
 
       // Use shorter cache for AI-expanded queries since results may vary
       const cacheControl = shouldUseAI && expandedTerms
@@ -179,10 +185,10 @@ export async function POST(request: NextRequest) {
 
       return NextResponse.json(
         {
-          results,
+          results: hybridResult.results,
           searchType: "semantic",
           expandedQuery: expandedTerms,
-          hasMore: results.length === limit,
+          hasMore: hybridResult.hasMore,
         },
         {
           headers: {
@@ -192,13 +198,13 @@ export async function POST(request: NextRequest) {
       );
     } catch (error) {
       logger.error("Semantic search failed, falling back to text:", error);
-      const results = await textSearch(trimmedQuery, sourceFilter, limit, offset);
+      const textResult = await textSearch(trimmedQuery, sourceFilter, limit, offset);
       return NextResponse.json(
         {
-          results,
+          results: textResult.results,
           searchType: "text",
           fallback: true,
-          hasMore: results.length === limit,
+          hasMore: textResult.hasMore,
         },
         {
           headers: {
@@ -294,7 +300,7 @@ async function hybridSearch(
   sourceId: string | undefined,
   limit: number,
   offset: number = 0
-): Promise<SearchResult[]> {
+): Promise<{ results: SearchResult[]; hasMore: boolean }> {
   // Get embedding for the expanded query
   const queryEmbedding = await getEmbedding(expandedQuery);
   const vectorString = embeddingToVectorString(queryEmbedding);
@@ -393,9 +399,11 @@ async function hybridSearch(
     });
   }
 
-  // Sort by hybrid score descending, apply offset, and return requested page
+  // Sort by hybrid score descending and create a limit+1 page window
   scored.sort((a, b) => b.score - a.score);
-  return scored.slice(offset, offset + limit);
+  const pageWindow = scored.slice(offset, offset + limit + 1);
+  const { items: results, hasMore } = sliceForPagination(pageWindow, limit);
+  return { results, hasMore };
 }
 
 /**
@@ -406,7 +414,7 @@ async function textSearch(
   sourceId: string | undefined,
   limit: number,
   offset: number = 0
-): Promise<SearchResult[]> {
+): Promise<{ results: SearchResult[]; hasMore: boolean }> {
   const searchTerm = `%${query.toLowerCase()}%`;
 
   const conditions = [
@@ -423,7 +431,7 @@ async function textSearch(
       .from(icons)
       .where(sql`${eq(icons.sourceId, sourceId)} AND (${or(...conditions)})`)
       .orderBy(asc(icons.normalizedName))
-      .limit(limit)
+      .limit(limit + 1)
       .offset(offset);
   } else {
     results = await db
@@ -431,11 +439,10 @@ async function textSearch(
       .from(icons)
       .where(or(...conditions))
       .orderBy(asc(icons.normalizedName))
-      .limit(limit)
+      .limit(limit + 1)
       .offset(offset);
   }
-
-  return results.map((icon) => ({
+  const mappedResults = results.map((icon) => ({
     id: icon.id,
     name: icon.name,
     normalizedName: icon.normalizedName,
@@ -451,4 +458,6 @@ async function textSearch(
     brandColor: icon.brandColor ?? null,
     score: 1, // Text matches get score of 1
   }));
+  const { items, hasMore } = sliceForPagination(mappedResults, limit);
+  return { results: items, hasMore };
 }

--- a/src/lib/api/pagination.ts
+++ b/src/lib/api/pagination.ts
@@ -9,6 +9,11 @@ export interface PaginationValidationError {
 
 type ParsePaginationResult = ParsedPagination | PaginationValidationError;
 
+export interface PaginatedSlice<T> {
+  items: T[];
+  hasMore: boolean;
+}
+
 function isValidationError(
   result: number | PaginationValidationError
 ): result is PaginationValidationError {
@@ -81,5 +86,18 @@ export function parsePagination(params: {
   return {
     limit: parsedLimit,
     offset: parsedOffset,
+  };
+}
+
+/**
+ * Builds paginated output from a "limit + 1" result set.
+ *
+ * Callers should fetch one extra row. If present, we know there is a next page.
+ */
+export function sliceForPagination<T>(rows: T[], limit: number): PaginatedSlice<T> {
+  const hasMore = rows.length > limit;
+  return {
+    items: hasMore ? rows.slice(0, limit) : rows,
+    hasMore,
   };
 }


### PR DESCRIPTION
## Summary
- add shared limit+1 pagination slicing helper for consistent hasMore calculation
- update /api/icons text and semantic paths to compute hasMore from an extra fetched row
- update /api/search text, semantic, and fallback paths to return accurate hasMore
- add pagination helper tests for exact-boundary behavior

## Testing
- pnpm -s lint
- pnpm -s typecheck
- pnpm -s test

Closes #50

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pagination behavior and response metadata across multiple search endpoints; small logic shift but can affect client paging and cache expectations.
> 
> **Overview**
> Fixes `hasMore` pagination metadata across icon/search APIs by switching to a consistent *limit+1* strategy.
> 
> Adds a shared `sliceForPagination` helper in `src/lib/api/pagination.ts`, updates `/api/icons` (text + AI semantic + fallback paths) and `/api/search` (text, hybrid semantic, and fallback paths) to fetch one extra row and compute `{items/results, hasMore}` from that slice instead of `results.length === limit`, and adds unit tests covering boundary behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3920dbfc381453c8018c5cb712cd023bd826423a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->