### PR TITLE
fix: return 404 when bundle delete matches no rows

### DIFF
--- a/src/app/api/bundles/[id]/route.test.ts
+++ b/src/app/api/bundles/[id]/route.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DELETE } from "./route";
+import { createClient } from "@/lib/supabase/server";
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(),
+}));
+
+type MockSupabaseClient = {
+  auth: {
+    getUser: ReturnType<typeof vi.fn>;
+  };
+  from: ReturnType<typeof vi.fn>;
+};
+
+function createDeleteChain(result: { data: Array<{ id: string }>; error: { message: string } | null }) {
+  const select = vi.fn().mockResolvedValue(result);
+  const eqUser = vi.fn().mockReturnValue({ select });
+  const eqId = vi.fn().mockReturnValue({ eq: eqUser });
+  const del = vi.fn().mockReturnValue({ eq: eqId });
+  const from = vi.fn().mockReturnValue({ delete: del });
+
+  return {
+    from,
+    del,
+    eqId,
+    eqUser,
+    select,
+  };
+}
+
+describe("DELETE /api/bundles/[id]", () => {
+  const createClientMock = vi.mocked(createClient);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 when user is not authenticated", async () => {
+    const supabase: MockSupabaseClient = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: null },
+          error: { message: "unauthorized" },
+        }),
+      },
+      from: vi.fn(),
+    };
+
+    createClientMock.mockResolvedValue(supabase as unknown as Awaited<ReturnType<typeof createClient>>);
+
+    const response = await DELETE(new Request("https://example.com/api/bundles/abc"), {
+      params: Promise.resolve({ id: "abc" }),
+    });
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: "Unauthorized" });
+    expect(supabase.from).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when no bundle row is deleted", async () => {
+    const chain = createDeleteChain({ data: [], error: null });
+    const supabase: MockSupabaseClient = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: "user-1" } },
+          error: null,
+        }),
+      },
+      from: chain.from,
+    };
+
+    createClientMock.mockResolvedValue(supabase as unknown as Awaited<ReturnType<typeof createClient>>);
+
+    const response = await DELETE(new Request("https://example.com/api/bundles/bundle-1"), {
+      params: Promise.resolve({ id: "bundle-1" }),
+    });
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: "Bundle not found or unauthorized",
+    });
+
+    expect(chain.from).toHaveBeenCalledWith("bundles");
+    expect(chain.del).toHaveBeenCalled();
+    expect(chain.eqId).toHaveBeenCalledWith("id", "bundle-1");
+    expect(chain.eqUser).toHaveBeenCalledWith("user_id", "user-1");
+    expect(chain.select).toHaveBeenCalledWith("id");
+  });
+
+  it("returns 200 when a bundle row is deleted", async () => {
+    const chain = createDeleteChain({ data: [{ id: "bundle-1" }], error: null });
+    const supabase: MockSupabaseClient = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: "user-1" } },
+          error: null,
+        }),
+      },
+      from: chain.from,
+    };
+
+    createClientMock.mockResolvedValue(supabase as unknown as Awaited<ReturnType<typeof createClient>>);
+
+    const response = await DELETE(new Request("https://example.com/api/bundles/bundle-1"), {
+      params: Promise.resolve({ id: "bundle-1" }),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ success: true });
+  });
+});

--- a/src/app/api/bundles/[id]/route.ts
+++ b/src/app/api/bundles/[id]/route.ts
@@ -156,14 +156,19 @@ export async function DELETE(request: Request, { params }: RouteParams) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const { error } = await supabase
+    const { data: deletedRows, error } = await supabase
       .from("bundles")
       .delete()
       .eq("id", id)
-      .eq("user_id", user.id);
+      .eq("user_id", user.id)
+      .select("id");
 
     if (error) {
       return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    if (!deletedRows || deletedRows.length === 0) {
+      return NextResponse.json({ error: "Bundle not found or unauthorized" }, { status: 404 });
     }
 
     return NextResponse.json({ success: true });


### PR DESCRIPTION
## Summary
- update DELETE /api/bundles/[id] to inspect deleted rows via delete(...).select("id")
- return 404 when no bundle row matches id + user_id
- keep 200 success when a row is actually deleted
- add route-level tests for unauthorized, not-found, and success delete paths

## Testing
- pnpm -s lint
- pnpm -s typecheck
- pnpm -s test

Closes #51

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, well-covered change limited to a single delete endpoint’s response semantics; main risk is client behavior relying on the previous always-200 delete response.
> 
> **Overview**
> `DELETE /api/bundles/[id]` now checks the deleted row set by using `.delete(...).select("id")` and returns **404** when the `id + user_id` filter matches no rows, instead of always reporting success.
> 
> Adds Vitest route tests that mock Supabase to cover **401 unauthenticated**, **404 no rows deleted**, and **200 successful deletion** paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 66c5e7316929a92b3cf3687ed4bd13c7b8d48fe9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->