### PR TITLE
fix: validate days query param for admin analytics

### DIFF
--- a/src/app/api/admin/analytics/route.test.ts
+++ b/src/app/api/admin/analytics/route.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextResponse } from "next/server";
+import { GET } from "./route";
+import { getSearchStats } from "@/lib/analytics";
+import { requireAdminAuth } from "@/lib/auth/admin";
+
+vi.mock("@/lib/analytics", () => ({
+  getSearchStats: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/admin", () => ({
+  requireAdminAuth: vi.fn(),
+}));
+
+describe("GET /api/admin/analytics", () => {
+  const getSearchStatsMock = vi.mocked(getSearchStats);
+  const requireAdminAuthMock = vi.mocked(requireAdminAuth);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireAdminAuthMock.mockReturnValue(null);
+  });
+
+  it("returns auth response when admin auth fails", async () => {
+    const authResponse = NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    requireAdminAuthMock.mockReturnValue(authResponse);
+
+    const response = await GET(
+      new Request("https://example.com/api/admin/analytics") as unknown as Parameters<typeof GET>[0]
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: "Unauthorized" });
+    expect(getSearchStatsMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when days is not an integer", async () => {
+    const response = await GET(
+      new Request("https://example.com/api/admin/analytics?days=abc") as unknown as Parameters<typeof GET>[0]
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "days must be an integer between 1 and 365",
+    });
+    expect(getSearchStatsMock).not.toHaveBeenCalled();
+  });
+
+  it.each(["0", "366"])("returns 400 when days=%s is out of range", async (days) => {
+    const response = await GET(
+      new Request(`https://example.com/api/admin/analytics?days=${days}`) as unknown as Parameters<
+        typeof GET
+      >[0]
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "days must be an integer between 1 and 365",
+    });
+    expect(getSearchStatsMock).not.toHaveBeenCalled();
+  });
+
+  it("uses default days when query param is omitted", async () => {
+    getSearchStatsMock.mockResolvedValue({ period: "7 days", summary: {}, popularQueries: [] });
+
+    const response = await GET(
+      new Request("https://example.com/api/admin/analytics") as unknown as Parameters<typeof GET>[0]
+    );
+
+    expect(response.status).toBe(200);
+    expect(getSearchStatsMock).toHaveBeenCalledWith(7);
+    await expect(response.json()).resolves.toEqual({
+      period: "7 days",
+      summary: {},
+      popularQueries: [],
+    });
+  });
+
+  it("passes validated days to analytics query", async () => {
+    getSearchStatsMock.mockResolvedValue({ period: "30 days", summary: {}, popularQueries: [] });
+
+    const response = await GET(
+      new Request("https://example.com/api/admin/analytics?days=30") as unknown as Parameters<typeof GET>[0]
+    );
+
+    expect(response.status).toBe(200);
+    expect(getSearchStatsMock).toHaveBeenCalledWith(30);
+    await expect(response.json()).resolves.toEqual({
+      period: "30 days",
+      summary: {},
+      popularQueries: [],
+    });
+  });
+});

--- a/src/app/api/admin/analytics/route.ts
+++ b/src/app/api/admin/analytics/route.ts
@@ -3,6 +3,10 @@ import { getSearchStats } from "@/lib/analytics";
 import { logger } from "@/lib/logger";
 import { requireAdminAuth } from "@/lib/auth/admin";
 
+const DEFAULT_DAYS = 7;
+const MIN_DAYS = 1;
+const MAX_DAYS = 365;
+
 /**
  * Get search analytics statistics
  * GET /api/admin/analytics?days=7
@@ -14,7 +18,13 @@ export async function GET(request: NextRequest) {
   }
 
   const { searchParams } = new URL(request.url);
-  const days = parseInt(searchParams.get("days") ?? "7", 10);
+  const days = parseDaysParam(searchParams.get("days"));
+  if (days === null) {
+    return NextResponse.json(
+      { error: `days must be an integer between ${MIN_DAYS} and ${MAX_DAYS}` },
+      { status: 400 }
+    );
+  }
 
   try {
     const stats = await getSearchStats(days);
@@ -31,4 +41,22 @@ export async function GET(request: NextRequest) {
       { status: 500 }
     );
   }
+}
+
+function parseDaysParam(rawDays: string | null): number | null {
+  if (rawDays === null) {
+    return DEFAULT_DAYS;
+  }
+
+  const trimmed = rawDays.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    return null;
+  }
+
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!Number.isSafeInteger(parsed) || parsed < MIN_DAYS || parsed > MAX_DAYS) {
+    return null;
+  }
+
+  return parsed;
 }


### PR DESCRIPTION
## Summary
- add strict days query validation for GET /api/admin/analytics
- default to 7 days when omitted
- reject non-integer or out-of-range values with 400 and a clear error message
- add route tests covering auth short-circuit, invalid days, default days, and valid explicit days

## Testing
- pnpm -s lint
- pnpm -s typecheck
- pnpm -s test

Closes #53

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, well-tested input-validation change to a single admin endpoint; primary risk is minor behavior change for previously accepted malformed `days` values.
> 
> **Overview**
> `GET /api/admin/analytics` now **strictly validates** the optional `days` query param, defaulting to `7` when omitted and returning a `400` with a clear error message when the value is non-integer or outside `1..365`.
> 
> Adds Vitest coverage for the route, including admin-auth short-circuit behavior, invalid `days` inputs, default behavior, and passing validated values through to `getSearchStats`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 196b7659934e1b5e18aff2c7eb0e771912ddd18c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->