### PR TITLE
fix: validate batchSize for admin embedding generation

### DIFF
--- a/src/app/api/admin/generate-embeddings/route.test.ts
+++ b/src/app/api/admin/generate-embeddings/route.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextResponse } from "next/server";
+import { POST } from "./route";
+import { requireAdminAuth } from "@/lib/auth/admin";
+import { getEmbeddings } from "@/lib/ai";
+import { db } from "@/lib/db";
+
+vi.mock("@/lib/auth/admin", () => ({
+  requireAdminAuth: vi.fn(),
+}));
+
+vi.mock("@/lib/ai", () => ({
+  getEmbeddings: vi.fn(),
+  embeddingToBlob: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+
+describe("POST /api/admin/generate-embeddings", () => {
+  const requireAdminAuthMock = vi.mocked(requireAdminAuth);
+  const getEmbeddingsMock = vi.mocked(getEmbeddings);
+  const dbSelectMock = vi.mocked(db.select);
+  const dbUpdateMock = vi.mocked(db.update);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireAdminAuthMock.mockReturnValue(null);
+  });
+
+  it("returns auth response when admin auth fails", async () => {
+    const authResponse = NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    requireAdminAuthMock.mockReturnValue(authResponse);
+
+    const response = await POST(
+      new Request("https://example.com/api/admin/generate-embeddings") as unknown as Parameters<
+        typeof POST
+      >[0]
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: "Unauthorized" });
+    expect(getEmbeddingsMock).not.toHaveBeenCalled();
+    expect(dbSelectMock).not.toHaveBeenCalled();
+  });
+
+  it.each(["abc", "0", "-1", "501", "1.5"])(
+    "returns 400 for invalid batchSize=%s",
+    async (batchSize) => {
+      const response = await POST(
+        new Request(
+          `https://example.com/api/admin/generate-embeddings?batchSize=${batchSize}`
+        ) as unknown as Parameters<typeof POST>[0]
+      );
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toEqual({
+        error: "batchSize must be an integer between 1 and 500",
+      });
+      expect(getEmbeddingsMock).not.toHaveBeenCalled();
+      expect(dbSelectMock).not.toHaveBeenCalled();
+      expect(dbUpdateMock).not.toHaveBeenCalled();
+    }
+  );
+});

--- a/src/app/api/admin/generate-embeddings/route.ts
+++ b/src/app/api/admin/generate-embeddings/route.ts
@@ -7,6 +7,8 @@ import { logger } from "@/lib/logger";
 import { requireAdminAuth } from "@/lib/auth/admin";
 
 const BATCH_SIZE = 100;
+const MIN_BATCH_SIZE = 1;
+const MAX_BATCH_SIZE = 500;
 const MAX_BATCHES_PER_REQUEST = 10; // Process up to 1000 icons per request
 
 /**
@@ -28,10 +30,13 @@ export async function POST(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
     const sourceId = searchParams.get("source");
-    const batchSize = Math.min(
-      parseInt(searchParams.get("batchSize") || String(BATCH_SIZE), 10),
-      500
-    );
+    const batchSize = parseBatchSizeParam(searchParams.get("batchSize"));
+    if (batchSize === null) {
+      return NextResponse.json(
+        { error: `batchSize must be an integer between ${MIN_BATCH_SIZE} and ${MAX_BATCH_SIZE}` },
+        { status: 400 }
+      );
+    }
 
     let totalProcessed = 0;
     let batchesProcessed = 0;
@@ -209,4 +214,26 @@ function buildSearchText(icon: {
   // Deduplicate and join
   const unique = [...new Set(parts)];
   return unique.join(" ");
+}
+
+function parseBatchSizeParam(rawBatchSize: string | null): number | null {
+  if (rawBatchSize === null) {
+    return BATCH_SIZE;
+  }
+
+  const trimmed = rawBatchSize.trim();
+  if (!/^-?\d+$/.test(trimmed)) {
+    return null;
+  }
+
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!Number.isSafeInteger(parsed)) {
+    return null;
+  }
+
+  if (parsed < MIN_BATCH_SIZE || parsed > MAX_BATCH_SIZE) {
+    return null;
+  }
+
+  return parsed;
 }


### PR DESCRIPTION
## Summary
- add strict batchSize validation for POST /api/admin/generate-embeddings
- default batchSize to 100 when omitted
- reject invalid or out-of-range values with 400 (allowed range: 1..500)
- add route tests for auth short-circuit and invalid batchSize values (abc, 0, -1, 501, 1.5)

## Testing
- pnpm -s lint
- pnpm -s typecheck
- pnpm -s test

Closes #54

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, well-scoped validation change to an admin-only endpoint plus tests; main risk is rejecting previously accepted but invalid `batchSize` inputs.
> 
> **Overview**
> Tightens input handling for `POST /api/admin/generate-embeddings` by introducing strict parsing/validation of the `batchSize` query param (defaults to 100; rejects non-integers and values outside **1..500** with a `400`).
> 
> Adds a new `route.test.ts` verifying the admin-auth short-circuit behavior and that invalid `batchSize` values return `400` without calling embedding generation or DB operations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb02f007ee410a6acf8621ccf10373b018d0b331. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->