### PR TITLE
fix: guard stripe webhook route when secret is missing

### DIFF
--- a/src/app/api/webhooks/stripe/route.test.ts
+++ b/src/app/api/webhooks/stripe/route.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { headers } from "next/headers";
+import { POST } from "./route";
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn(),
+}));
+
+describe("POST /api/webhooks/stripe", () => {
+  const headersMock = vi.mocked(headers);
+  const originalWebhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    if (originalWebhookSecret === undefined) {
+      delete process.env.STRIPE_WEBHOOK_SECRET;
+    } else {
+      process.env.STRIPE_WEBHOOK_SECRET = originalWebhookSecret;
+    }
+  });
+
+  it("returns 503 when STRIPE_WEBHOOK_SECRET is not configured", async () => {
+    delete process.env.STRIPE_WEBHOOK_SECRET;
+
+    const response = await POST(
+      new Request("https://example.com/api/webhooks/stripe", {
+        method: "POST",
+        body: "{}",
+      })
+    );
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      error: "Stripe webhook is not configured",
+    });
+    expect(headersMock).not.toHaveBeenCalled();
+  });
+
+  it("continues normal validation flow when webhook secret is configured", async () => {
+    process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
+    headersMock.mockResolvedValue(new Headers());
+
+    const response = await POST(
+      new Request("https://example.com/api/webhooks/stripe", {
+        method: "POST",
+        body: "{}",
+      })
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "No signature" });
+    expect(headersMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -6,8 +6,6 @@ import { logger } from "@/lib/logger";
 import { mapStripeSubscriptionStatus } from "@/lib/stripe-webhook";
 import type Stripe from "stripe";
 
-const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET!;
-
 // Track processed events to ensure idempotency (in-memory for single instance)
 // In production with multiple instances, use Redis or database
 const processedEvents = new Map<string, number>();
@@ -40,6 +38,15 @@ function markEventProcessed(eventId: string): void {
 }
 
 export async function POST(request: Request) {
+  const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
+  if (!webhookSecret) {
+    logger.error("STRIPE_WEBHOOK_SECRET is not configured for webhook processing");
+    return NextResponse.json(
+      { error: "Stripe webhook is not configured" },
+      { status: 503 }
+    );
+  }
+
   const body = await request.text();
   const headersList = await headers();
   const signature = headersList.get("stripe-signature");


### PR DESCRIPTION
## Summary
- remove non-null assertion usage for STRIPE_WEBHOOK_SECRET in webhook route
- add explicit runtime configuration guard that returns 503 when secret is missing
- keep existing signature verification and webhook processing behavior when configured
- add route tests for missing-secret guard and configured missing-signature path

## Testing
- pnpm -s lint
- pnpm -s typecheck
- pnpm -s test

Closes #55

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a simple runtime guard and tests around Stripe webhook configuration; behavior only changes in misconfigured deployments and does not alter normal webhook processing.
> 
> **Overview**
> Prevents the Stripe webhook handler from crashing when `STRIPE_WEBHOOK_SECRET` is missing by replacing the non-null assertion with a runtime check that logs an error and returns `503` with a clear JSON message.
> 
> Adds Vitest coverage for both the missing-secret path (ensuring `next/headers` isn’t touched) and the configured path continuing into the existing signature validation flow (returning `400` when no signature is provided).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 835e5f970dd430251753b9472b055d15a90f6ba6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->