### PR TITLE
fix: persist stripe webhook idempotency across instances

### DIFF
--- a/src/app/api/webhooks/stripe/route.test.ts
+++ b/src/app/api/webhooks/stripe/route.test.ts
@@ -1,13 +1,78 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { headers } from "next/headers";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { stripe } from "@/lib/stripe";
 import { POST } from "./route";
 
 vi.mock("next/headers", () => ({
   headers: vi.fn(),
 }));
 
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(),
+}));
+
+vi.mock("@/lib/stripe", () => ({
+  stripe: {
+    webhooks: {
+      constructEvent: vi.fn(),
+    },
+    subscriptions: {
+      retrieve: vi.fn(),
+    },
+  },
+}));
+
+function createWebhookEventsTableMock({
+  insertResult,
+  selectResult,
+  updateResults,
+}: {
+  insertResult: { error: { code?: string; message: string } | null };
+  selectResult?: { data: Record<string, unknown> | null; error: { message: string } | null };
+  updateResults?: Array<{ data: Record<string, unknown> | null; error: { message: string } | null }>;
+}) {
+  const insert = vi.fn().mockResolvedValue(insertResult);
+
+  const selectBuilder = {
+    eq: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn().mockResolvedValue(selectResult ?? { data: null, error: null }),
+  };
+  const select = vi.fn().mockReturnValue(selectBuilder);
+
+  const updateQueue = [...(updateResults ?? [])];
+  const updateBuilder = {
+    eq: vi.fn().mockReturnThis(),
+    is: vi.fn().mockReturnThis(),
+    lt: vi.fn().mockReturnThis(),
+    select: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn().mockImplementation(() =>
+      Promise.resolve(updateQueue.shift() ?? { data: null, error: null })
+    ),
+  };
+  const update = vi.fn().mockReturnValue(updateBuilder);
+
+  const deleteBuilder = {
+    eq: vi.fn().mockReturnThis(),
+    is: vi.fn().mockResolvedValue({ error: null }),
+  };
+  const del = vi.fn().mockReturnValue(deleteBuilder);
+
+  return {
+    insert,
+    select,
+    selectBuilder,
+    update,
+    updateBuilder,
+    del,
+    deleteBuilder,
+  };
+}
+
 describe("POST /api/webhooks/stripe", () => {
   const headersMock = vi.mocked(headers);
+  const createAdminClientMock = vi.mocked(createAdminClient);
+  const constructEventMock = vi.mocked(stripe.webhooks.constructEvent);
   const originalWebhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
 
   beforeEach(() => {
@@ -53,5 +118,94 @@ describe("POST /api/webhooks/stripe", () => {
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toEqual({ error: "No signature" });
     expect(headersMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("processes event and marks it as processed when claim succeeds", async () => {
+    process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
+    headersMock.mockResolvedValue(new Headers({ "stripe-signature": "sig" }));
+    constructEventMock.mockReturnValue({
+      id: "evt_1",
+      type: "invoice.created",
+    } as never);
+
+    const eventsTable = createWebhookEventsTableMock({
+      insertResult: { error: null },
+      updateResults: [{ data: { event_id: "evt_1" }, error: null }],
+    });
+
+    createAdminClientMock.mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === "stripe_webhook_events") {
+          return {
+            insert: eventsTable.insert,
+            select: eventsTable.select,
+            update: eventsTable.update,
+            delete: eventsTable.del,
+          };
+        }
+
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    } as unknown as ReturnType<typeof createAdminClient>);
+
+    const response = await POST(
+      new Request("https://example.com/api/webhooks/stripe", {
+        method: "POST",
+        body: "{}",
+      })
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ received: true });
+    expect(eventsTable.insert).toHaveBeenCalledTimes(1);
+    expect(eventsTable.update).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips duplicate event when existing record is already processed", async () => {
+    process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
+    headersMock.mockResolvedValue(new Headers({ "stripe-signature": "sig" }));
+    constructEventMock.mockReturnValue({
+      id: "evt_dup",
+      type: "invoice.created",
+    } as never);
+
+    const eventsTable = createWebhookEventsTableMock({
+      insertResult: { error: { code: "23505", message: "duplicate key value" } },
+      selectResult: {
+        data: {
+          status: "processed",
+          processed_at: new Date().toISOString(),
+          last_attempt_at: new Date().toISOString(),
+        },
+        error: null,
+      },
+    });
+
+    createAdminClientMock.mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === "stripe_webhook_events") {
+          return {
+            insert: eventsTable.insert,
+            select: eventsTable.select,
+            update: eventsTable.update,
+            delete: eventsTable.del,
+          };
+        }
+
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    } as unknown as ReturnType<typeof createAdminClient>);
+
+    const response = await POST(
+      new Request("https://example.com/api/webhooks/stripe", {
+        method: "POST",
+        body: "{}",
+      })
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ received: true, skipped: true });
+    expect(eventsTable.select).toHaveBeenCalledTimes(1);
+    expect(eventsTable.update).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -6,36 +6,13 @@ import { logger } from "@/lib/logger";
 import { mapStripeSubscriptionStatus } from "@/lib/stripe-webhook";
 import type Stripe from "stripe";
 
-// Track processed events to ensure idempotency (in-memory for single instance)
-// In production with multiple instances, use Redis or database
-const processedEvents = new Map<string, number>();
-const EVENT_TTL = 60 * 60 * 1000; // 1 hour
+const EVENT_CLAIM_STALE_MS = 5 * 60 * 1000; // 5 minutes
 
-function isEventProcessed(eventId: string): boolean {
-  const timestamp = processedEvents.get(eventId);
-  if (!timestamp) return false;
-  
-  // Check if event is still within TTL
-  if (Date.now() - timestamp > EVENT_TTL) {
-    processedEvents.delete(eventId);
-    return false;
-  }
-  return true;
-}
-
-function markEventProcessed(eventId: string): void {
-  processedEvents.set(eventId, Date.now());
-  
-  // Prune old entries periodically
-  if (processedEvents.size > 1000) {
-    const now = Date.now();
-    for (const [id, ts] of processedEvents.entries()) {
-      if (now - ts > EVENT_TTL) {
-        processedEvents.delete(id);
-      }
-    }
-  }
-}
+type EventClaimResult =
+  | { kind: "claimed" }
+  | { kind: "already_processed" }
+  | { kind: "in_progress" }
+  | { kind: "error"; message: string };
 
 export async function POST(request: Request) {
   const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
@@ -64,13 +41,18 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Invalid signature" }, { status: 400 });
   }
 
-  // Idempotency check - prevent duplicate processing
-  if (isEventProcessed(event.id)) {
-    logger.log(`Event ${event.id} already processed, skipping`);
+  const supabase = createAdminClient();
+  const claim = await claimEventForProcessing(supabase, event.id);
+
+  if (claim.kind === "already_processed" || claim.kind === "in_progress") {
+    logger.log(`Event ${event.id} already being handled or processed, skipping`);
     return NextResponse.json({ received: true, skipped: true });
   }
 
-  const supabase = createAdminClient();
+  if (claim.kind === "error") {
+    logger.error(`Failed idempotency claim for event ${event.id}: ${claim.message}`);
+    return NextResponse.json({ error: "Webhook idempotency check failed" }, { status: 500 });
+  }
 
   try {
     switch (event.type) {
@@ -173,11 +155,134 @@ export async function POST(request: Request) {
     }
 
     // Mark event as processed after successful handling
-    markEventProcessed(event.id);
+    await markEventAsProcessed(supabase, event.id);
 
     return NextResponse.json({ received: true });
   } catch (err) {
+    await releaseEventClaim(supabase, event.id);
     logger.error("Webhook handler error:", err);
     return NextResponse.json({ error: "Webhook handler failed" }, { status: 500 });
   }
+}
+
+async function claimEventForProcessing(
+  supabase: ReturnType<typeof createAdminClient>,
+  eventId: string
+): Promise<EventClaimResult> {
+  const nowIso = new Date().toISOString();
+
+  const { error: insertError } = await supabase.from("stripe_webhook_events").insert({
+    event_id: eventId,
+    status: "processing",
+    last_attempt_at: nowIso,
+  });
+
+  if (!insertError) {
+    return { kind: "claimed" };
+  }
+
+  // Unique violation means another attempt has already claimed this event ID.
+  if (insertError.code !== "23505") {
+    return { kind: "error", message: insertError.message };
+  }
+
+  const { data: existing, error: existingError } = await supabase
+    .from("stripe_webhook_events")
+    .select("status, processed_at, last_attempt_at")
+    .eq("event_id", eventId)
+    .maybeSingle();
+
+  if (existingError) {
+    return { kind: "error", message: existingError.message };
+  }
+
+  if (!existing) {
+    return { kind: "error", message: "Webhook event state not found after duplicate claim" };
+  }
+
+  if (existing.processed_at || existing.status === "processed") {
+    return { kind: "already_processed" };
+  }
+
+  if (!isClaimStale(existing.last_attempt_at)) {
+    return { kind: "in_progress" };
+  }
+
+  // Reclaim stale in-progress events so retries can recover from crashes.
+  const staleBeforeIso = new Date(Date.now() - EVENT_CLAIM_STALE_MS).toISOString();
+  const { data: reclaimed, error: reclaimError } = await supabase
+    .from("stripe_webhook_events")
+    .update({
+      status: "processing",
+      last_attempt_at: nowIso,
+    })
+    .eq("event_id", eventId)
+    .eq("status", "processing")
+    .is("processed_at", null)
+    .lt("last_attempt_at", staleBeforeIso)
+    .select("event_id")
+    .maybeSingle();
+
+  if (reclaimError) {
+    return { kind: "error", message: reclaimError.message };
+  }
+
+  return reclaimed ? { kind: "claimed" } : { kind: "in_progress" };
+}
+
+async function markEventAsProcessed(
+  supabase: ReturnType<typeof createAdminClient>,
+  eventId: string
+): Promise<void> {
+  const nowIso = new Date().toISOString();
+
+  const { data, error } = await supabase
+    .from("stripe_webhook_events")
+    .update({
+      status: "processed",
+      processed_at: nowIso,
+      last_attempt_at: nowIso,
+    })
+    .eq("event_id", eventId)
+    .eq("status", "processing")
+    .is("processed_at", null)
+    .select("event_id")
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`Failed to mark webhook event ${eventId} as processed: ${error.message}`);
+  }
+
+  if (!data) {
+    throw new Error(`Missing webhook claim while marking event ${eventId} as processed`);
+  }
+}
+
+async function releaseEventClaim(
+  supabase: ReturnType<typeof createAdminClient>,
+  eventId: string
+): Promise<void> {
+  const { error } = await supabase
+    .from("stripe_webhook_events")
+    .delete()
+    .eq("event_id", eventId)
+    .eq("status", "processing")
+    .is("processed_at", null);
+
+  if (error) {
+    logger.warn(`Failed to release webhook claim for ${eventId}: ${error.message}`);
+  }
+}
+
+function isClaimStale(lastAttemptAt: string | null): boolean {
+  if (!lastAttemptAt) {
+    return true;
+  }
+
+  const lastAttemptMs = Date.parse(lastAttemptAt);
+  if (Number.isNaN(lastAttemptMs)) {
+    return true;
+  }
+
+  return Date.now() - lastAttemptMs > EVENT_CLAIM_STALE_MS;
 }

--- a/supabase/migrations/20260216010000_stripe_webhook_events.sql
+++ b/supabase/migrations/20260216010000_stripe_webhook_events.sql
@@ -1,0 +1,22 @@
+-- Persistent Stripe webhook idempotency tracking across instances/retries
+
+CREATE TABLE IF NOT EXISTS public.stripe_webhook_events (
+  event_id TEXT PRIMARY KEY,
+  status TEXT NOT NULL DEFAULT 'processing' CHECK (status IN ('processing', 'processed')),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_attempt_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  processed_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_stripe_webhook_events_status_attempt
+  ON public.stripe_webhook_events (status, last_attempt_at);
+
+ALTER TABLE public.stripe_webhook_events ENABLE ROW LEVEL SECURITY;
+
+-- Service-role only access in app code; block direct client access.
+DROP POLICY IF EXISTS "No direct access to webhook events" ON public.stripe_webhook_events;
+CREATE POLICY "No direct access to webhook events"
+  ON public.stripe_webhook_events
+  FOR ALL
+  USING (FALSE)
+  WITH CHECK (FALSE);


### PR DESCRIPTION
## Summary
- replace in-memory Stripe webhook dedupe with persistent database-backed event claims
- add stale-claim recovery logic to allow retries after failed/crashed processing attempts
- mark events as processed only after successful handler completion, and release claim on failures
- add migration for `stripe_webhook_events` tracking table and index
- add route tests for successful claim+process and duplicate already-processed skip behavior

## Migration validation
- Supabase CLI local validation run:
  - `supabase db reset --local --yes`
  - applied `20260216010000_stripe_webhook_events.sql` successfully

## Testing
- pnpm -s lint
- pnpm -s typecheck
- pnpm -s test

Closes #56

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes webhook idempotency and adds new persistent state in the database; mistakes could cause duplicate processing or dropped events in a billing-critical flow.
> 
> **Overview**
> Replaces in-memory Stripe webhook deduping with a **database-backed idempotency/claim flow** using a new `stripe_webhook_events` table, allowing safe processing across multiple instances and retries.
> 
> The webhook now **claims** an event before handling, **skips** events that are already processed or currently in progress, **reclaims** stale processing claims after 5 minutes, **marks processed** only on successful completion, and **releases** the claim on handler errors. Adds a Supabase migration (table + index + RLS deny-all policy) and expands route tests to cover successful claim/processing and duplicate processed skip behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1530b1964d7c2d8f6108976627d46e945103a271. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->