### PR TITLE
fix: enforce consistent pro policy for token bundle access

### DIFF
--- a/src/app/api/bundles/me/route.test.ts
+++ b/src/app/api/bundles/me/route.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { GET } from "./route";
+import { requireApiAuth } from "@/lib/auth/api-token";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+vi.mock("@/lib/auth/api-token", () => ({
+  requireApiAuth: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(),
+}));
+
+describe("GET /api/bundles/me", () => {
+  const requireApiAuthMock = vi.mocked(requireApiAuth);
+  const createAdminClientMock = vi.mocked(createAdminClient);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 403 with CORS headers when token user is not Pro", async () => {
+    requireApiAuthMock.mockRejectedValue(
+      new Response(
+        JSON.stringify({
+          error: "pro_required",
+          message: "API access requires a Pro subscription. Upgrade at https://unicon.sh/pricing",
+        }),
+        {
+          status: 403,
+          headers: { "Content-Type": "application/json" },
+        }
+      )
+    );
+
+    const response = await GET(
+      new Request("https://example.com/api/bundles/me", {
+        headers: { Authorization: "Bearer uni_nonpro" },
+      })
+    );
+
+    expect(response.status).toBe(403);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    await expect(response.json()).resolves.toEqual({
+      error: "pro_required",
+      message: "API access requires a Pro subscription. Upgrade at https://unicon.sh/pricing",
+    });
+    expect(createAdminClientMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/bundles/me/route.ts
+++ b/src/app/api/bundles/me/route.ts
@@ -1,17 +1,13 @@
 /**
  * GET /api/bundles/me
  * 
- * List all bundles for the authenticated user (via API token).
+ * List all bundles for the authenticated Pro user (via API token).
  * Used by MCP, CLI, and Figma plugin to fetch user's saved bundles.
- * 
- * Rate limits:
- * - Free users: 10 requests/minute
- * - Pro users: 100 requests/minute
  */
 
 import { NextResponse } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
-import { extractBearerToken, validateApiToken } from "@/lib/auth/api-token";
+import { requireApiAuth } from "@/lib/auth/api-token";
 import { checkRateLimit, getRateLimitHeaders } from "@/lib/rate-limit";
 import { logger } from "@/lib/logger";
 
@@ -28,43 +24,24 @@ export function OPTIONS() {
 
 export async function GET(request: Request) {
   try {
-    // Extract and validate token
-    const token = extractBearerToken(request);
-    
-    if (!token) {
-      return NextResponse.json(
-        { 
-          error: "unauthorized", 
-          message: "Missing Authorization header. Use 'unicon login' to authenticate." 
-        },
-        { status: 401, headers: CORS_HEADERS }
-      );
-    }
-
-    const validation = await validateApiToken(token);
-
-    if (!validation.valid) {
-      return NextResponse.json(
-        { 
-          error: "invalid_token", 
-          message: validation.error === "invalid_token" 
-            ? "Invalid or expired token. Use 'unicon login' to re-authenticate."
-            : `Token validation failed: ${validation.error}` 
-        },
-        { status: 401, headers: CORS_HEADERS }
-      );
+    let authContext;
+    try {
+      authContext = await requireApiAuth(request);
+    } catch (error) {
+      if (error instanceof Response) {
+        return await responseWithCors(error);
+      }
+      throw error;
     }
 
     // Check rate limit (different limits for free vs Pro)
-    const rateLimit = await checkRateLimit(validation.userId!, validation.isPro ?? false);
+    const rateLimit = await checkRateLimit(authContext.userId, authContext.isPro);
     
     if (!rateLimit.success) {
       return NextResponse.json(
         { 
           error: "rate_limit_exceeded", 
-          message: validation.isPro 
-            ? "Rate limit exceeded. Please wait before making more requests."
-            : "Rate limit exceeded. Upgrade to Pro for higher limits: https://unicon.sh/pricing"
+          message: "Rate limit exceeded. Please wait before making more requests."
         },
         { 
           status: 429,
@@ -79,7 +56,7 @@ export async function GET(request: Request) {
     const { data: bundles, error } = await supabase
       .from("bundles")
       .select("id, name, description, icon_count, is_public, share_slug, created_at, updated_at")
-      .eq("user_id", validation.userId)
+      .eq("user_id", authContext.userId)
       .order("updated_at", { ascending: false });
 
     if (error) {
@@ -111,4 +88,18 @@ export async function GET(request: Request) {
       { status: 500, headers: CORS_HEADERS }
     );
   }
+}
+
+async function responseWithCors(response: Response): Promise<NextResponse> {
+  let payload: unknown = { error: "Unauthorized" };
+  try {
+    payload = await response.json();
+  } catch {
+    // Fall back to default payload for non-JSON responses.
+  }
+
+  return NextResponse.json(payload, {
+    status: response.status,
+    headers: CORS_HEADERS,
+  });
 }

--- a/src/app/api/mcp/route.test.ts
+++ b/src/app/api/mcp/route.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { POST } from "./route";
+import { validateApiToken } from "@/lib/auth/api-token";
+import { checkPublicRateLimit } from "@/lib/rate-limit";
+import { getTrustedClientIp } from "@/lib/request-ip";
+import {
+  registerBundleTools,
+  registerIconTools,
+  registerResources,
+  registerSearchTools,
+  registerStarterPackTools,
+} from "./handlers";
+
+const mcpServerMocks = vi.hoisted(() => ({
+  connect: vi.fn().mockResolvedValue(undefined),
+  close: vi.fn().mockResolvedValue(undefined),
+  handleRequest: vi.fn(),
+}));
+
+vi.mock("@modelcontextprotocol/sdk/server/mcp.js", () => ({
+  McpServer: class {
+    constructor(config: unknown) {
+      void config;
+    }
+
+    connect = mcpServerMocks.connect;
+    close = mcpServerMocks.close;
+  },
+}));
+
+vi.mock("@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js", () => ({
+  WebStandardStreamableHTTPServerTransport: class {
+    constructor(opts: unknown) {
+      void opts;
+    }
+
+    handleRequest = mcpServerMocks.handleRequest;
+  },
+}));
+
+vi.mock("./handlers", () => ({
+  registerSearchTools: vi.fn(),
+  registerIconTools: vi.fn(),
+  registerStarterPackTools: vi.fn(),
+  registerResources: vi.fn(),
+  registerBundleTools: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/api-token", () => ({
+  validateApiToken: vi.fn(),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  checkPublicRateLimit: vi.fn(),
+  getRateLimitHeaders: vi.fn().mockReturnValue({
+    "X-RateLimit-Limit": "60",
+    "X-RateLimit-Remaining": "59",
+    "X-RateLimit-Reset": "123",
+  }),
+}));
+
+vi.mock("@/lib/request-ip", () => ({
+  getTrustedClientIp: vi.fn(),
+}));
+
+describe("POST /api/mcp auth policy", () => {
+  const validateApiTokenMock = vi.mocked(validateApiToken);
+  const checkPublicRateLimitMock = vi.mocked(checkPublicRateLimit);
+  const getTrustedClientIpMock = vi.mocked(getTrustedClientIp);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    checkPublicRateLimitMock.mockResolvedValue({
+      success: true,
+      limit: 60,
+      remaining: 59,
+      reset: 123,
+    });
+
+    getTrustedClientIpMock.mockReturnValue("203.0.113.10");
+
+    mcpServerMocks.handleRequest.mockResolvedValue(
+      new Response(JSON.stringify({ jsonrpc: "2.0", result: {} }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+  });
+
+  it("does not register bundle tools for valid non-Pro API tokens", async () => {
+    validateApiTokenMock.mockResolvedValue({
+      valid: true,
+      userId: "user_non_pro",
+      isPro: false,
+      scope: "bundles:read",
+    });
+
+    const response = await POST(
+      new Request("https://example.com/api/mcp", {
+        method: "POST",
+        headers: { Authorization: "Bearer uni_nonpro_token" },
+        body: "{}",
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(registerSearchTools).toHaveBeenCalledTimes(1);
+    expect(registerIconTools).toHaveBeenCalledTimes(1);
+    expect(registerStarterPackTools).toHaveBeenCalledTimes(1);
+    expect(registerResources).toHaveBeenCalledTimes(1);
+    expect(registerBundleTools).not.toHaveBeenCalled();
+  });
+
+  it("registers bundle tools for valid Pro API tokens", async () => {
+    validateApiTokenMock.mockResolvedValue({
+      valid: true,
+      userId: "user_pro",
+      isPro: true,
+      scope: "bundles:read",
+    });
+
+    const response = await POST(
+      new Request("https://example.com/api/mcp", {
+        method: "POST",
+        headers: { Authorization: "Bearer uni_pro_token" },
+        body: "{}",
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(registerBundleTools).toHaveBeenCalledTimes(1);
+    expect(registerBundleTools).toHaveBeenCalledWith(expect.any(Object), {
+      userId: "user_pro",
+      isPro: true,
+    });
+  });
+});

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -47,7 +47,7 @@ function withCors(response: Response): Response {
 
 // Create MCP server with all tools and resources
 function createMcpServer(authContext?: AuthContext) {
-  const isAuthenticated = !!authContext?.userId;
+  const hasBundleAccess = !!authContext?.userId && authContext.isPro;
 
   const server = new McpServer({
     name: "unicon",
@@ -59,11 +59,12 @@ AVAILABLE TOOLS:
 - get_icon: Get a single icon by ID (e.g., "lucide:arrow-right").
 - get_multiple_icons: Get multiple icons at once (up to 50).
 - get_starter_pack: Get curated icon packs (shadcn-ui, dashboard, ecommerce, etc.).
-${isAuthenticated ? `
+${hasBundleAccess ? `
 AUTHENTICATED TOOLS:
 - list_my_bundles: List your saved icon bundles.
 - get_my_bundle: Get icons from a saved bundle.
-- create_my_bundle: Create and save a new bundle.` : ""}
+- create_my_bundle: Create and save a new bundle.
+(Requires an active Pro API token.)` : ""}
 
 QUICK START:
 - For shadcn/ui: get_starter_pack({ packId: "shadcn-ui" })
@@ -79,8 +80,8 @@ Read unicon://instructions for detailed usage.`,
   registerStarterPackTools(server);
   registerResources(server);
 
-  // Register authenticated tools
-  if (isAuthenticated && authContext) {
+  // Register authenticated bundle tools (active Pro token required)
+  if (hasBundleAccess && authContext) {
     registerBundleTools(server, authContext);
   }
 


### PR DESCRIPTION
## Summary
- route `/api/bundles/me` through `requireApiAuth` for consistent token policy enforcement
- gate authenticated MCP bundle tools on active Pro API token status
- add focused route tests for non-Pro and Pro token behavior

## Validation
- pnpm -s lint
- pnpm -s typecheck
- pnpm -s test

Closes #57

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authorization behavior for bundle access and MCP tool exposure, which could break existing non-Pro clients if assumptions differ; scope is limited and covered by new tests.
> 
> **Overview**
> Routes `GET /api/bundles/me` through shared `requireApiAuth` (instead of ad-hoc bearer parsing), making bundle listing **Pro-token only** and ensuring auth failures (e.g., `pro_required`) return consistently with CORS headers.
> 
> Tightens `/api/mcp` so bundle-related tools/resources are only advertised and registered when the API token is **Pro**, and adds Vitest coverage for both non-Pro and Pro token behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 708e1dad738a37a01363c695d131e051b0d63694. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->