### PR TITLE
fix: add abuse controls to device authorization flow

### DIFF
--- a/src/app/api/auth/device/code/route.test.ts
+++ b/src/app/api/auth/device/code/route.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { POST } from "./route";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { checkDeviceCodeRateLimit } from "@/lib/rate-limit";
+import { getTrustedClientIp } from "@/lib/request-ip";
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  checkDeviceCodeRateLimit: vi.fn(),
+  getRateLimitHeaders: vi.fn().mockReturnValue({
+    "X-RateLimit-Limit": "10",
+    "X-RateLimit-Remaining": "0",
+    "X-RateLimit-Reset": "123",
+  }),
+}));
+
+vi.mock("@/lib/request-ip", () => ({
+  getTrustedClientIp: vi.fn(),
+}));
+
+describe("POST /api/auth/device/code", () => {
+  const createAdminClientMock = vi.mocked(createAdminClient);
+  const checkDeviceCodeRateLimitMock = vi.mocked(checkDeviceCodeRateLimit);
+  const getTrustedClientIpMock = vi.mocked(getTrustedClientIp);
+
+  const rpcMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    checkDeviceCodeRateLimitMock.mockResolvedValue({
+      success: true,
+      limit: 10,
+      remaining: 9,
+      reset: 123,
+    });
+
+    getTrustedClientIpMock.mockReturnValue("203.0.113.5");
+
+    rpcMock.mockResolvedValue({
+      data: [
+        {
+          device_code: "dev_123",
+          user_code: "ABCD-1234",
+          verification_uri: "https://unicon.sh/auth/device",
+          expires_in: 900,
+        },
+      ],
+      error: null,
+    });
+
+    createAdminClientMock.mockReturnValue({
+      rpc: rpcMock,
+    } as unknown as ReturnType<typeof createAdminClient>);
+  });
+
+  it("returns 429 when device-code endpoint rate limit is exceeded", async () => {
+    checkDeviceCodeRateLimitMock.mockResolvedValue({
+      success: false,
+      limit: 10,
+      remaining: 0,
+      reset: 123,
+    });
+
+    const response = await POST(
+      new Request("https://example.com/api/auth/device/code", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ client_name: "CLI", scope: "bundles:read" }),
+      })
+    );
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(response.headers.get("X-RateLimit-Limit")).toBe("10");
+    await expect(response.json()).resolves.toEqual({
+      error: "rate_limit_exceeded",
+      error_description: "Too many device authorization requests. Please try again shortly.",
+    });
+    expect(createAdminClientMock).not.toHaveBeenCalled();
+  });
+
+  it("creates a device code when within rate limit", async () => {
+    const response = await POST(
+      new Request("https://example.com/api/auth/device/code", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ client_name: "CLI", scope: "bundles:read" }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      device_code: "dev_123",
+      user_code: "ABCD-1234",
+      verification_uri: "https://unicon.sh/auth/device",
+      verification_uri_complete: "https://unicon.sh/auth/device?code=ABCD-1234",
+      expires_in: 900,
+      interval: 5,
+    });
+
+    expect(getTrustedClientIpMock).toHaveBeenCalledTimes(1);
+    expect(checkDeviceCodeRateLimitMock).toHaveBeenCalledWith("203.0.113.5");
+    expect(rpcMock).toHaveBeenCalledWith("create_device_code", {
+      p_client_name: "CLI",
+      p_scope: "bundles:read",
+    });
+  });
+});

--- a/src/app/api/auth/device/code/route.ts
+++ b/src/app/api/auth/device/code/route.ts
@@ -11,6 +11,8 @@
 import { NextResponse } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { logger } from "@/lib/logger";
+import { checkDeviceCodeRateLimit, getRateLimitHeaders } from "@/lib/rate-limit";
+import { getTrustedClientIp } from "@/lib/request-ip";
 
 const CORS_HEADERS = {
   "Access-Control-Allow-Origin": "*",
@@ -25,6 +27,22 @@ export function OPTIONS() {
 
 export async function POST(request: Request) {
   try {
+    const ip = getTrustedClientIp(request);
+    const rateLimit = await checkDeviceCodeRateLimit(ip);
+
+    if (!rateLimit.success) {
+      return NextResponse.json(
+        {
+          error: "rate_limit_exceeded",
+          error_description: "Too many device authorization requests. Please try again shortly.",
+        },
+        {
+          status: 429,
+          headers: { ...CORS_HEADERS, ...getRateLimitHeaders(rateLimit) },
+        }
+      );
+    }
+
     const body = await request.json().catch(() => ({}));
     const clientName = body.client_name || "CLI";
     const scope = body.scope || "bundles:read";

--- a/src/app/api/auth/device/token/route.test.ts
+++ b/src/app/api/auth/device/token/route.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { POST } from "./route";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { checkDeviceTokenRateLimit } from "@/lib/rate-limit";
+import { getTrustedClientIp } from "@/lib/request-ip";
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  checkDeviceTokenRateLimit: vi.fn(),
+  getRateLimitHeaders: vi.fn().mockReturnValue({
+    "X-RateLimit-Limit": "30",
+    "X-RateLimit-Remaining": "0",
+    "X-RateLimit-Reset": "123",
+  }),
+}));
+
+vi.mock("@/lib/request-ip", () => ({
+  getTrustedClientIp: vi.fn(),
+}));
+
+describe("POST /api/auth/device/token", () => {
+  const createAdminClientMock = vi.mocked(createAdminClient);
+  const checkDeviceTokenRateLimitMock = vi.mocked(checkDeviceTokenRateLimit);
+  const getTrustedClientIpMock = vi.mocked(getTrustedClientIp);
+
+  const rpcMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    checkDeviceTokenRateLimitMock.mockResolvedValue({
+      success: true,
+      limit: 30,
+      remaining: 29,
+      reset: 123,
+    });
+
+    getTrustedClientIpMock.mockReturnValue("203.0.113.6");
+
+    rpcMock.mockResolvedValue({
+      data: [
+        {
+          status: "pending",
+          access_token: null,
+          refresh_token: null,
+          expires_in: 900,
+          error: "authorization_pending",
+        },
+      ],
+      error: null,
+    });
+
+    createAdminClientMock.mockReturnValue({
+      rpc: rpcMock,
+    } as unknown as ReturnType<typeof createAdminClient>);
+  });
+
+  it("returns 429 when device-token endpoint rate limit is exceeded", async () => {
+    checkDeviceTokenRateLimitMock.mockResolvedValue({
+      success: false,
+      limit: 30,
+      remaining: 0,
+      reset: 123,
+    });
+
+    const response = await POST(
+      new Request("https://example.com/api/auth/device/token", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          device_code: "dev_rapid",
+          grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(response.headers.get("X-RateLimit-Limit")).toBe("30");
+    await expect(response.json()).resolves.toEqual({
+      error: "rate_limit_exceeded",
+      error_description: "Too many token polling requests. Please slow down and retry.",
+    });
+    expect(createAdminClientMock).not.toHaveBeenCalled();
+  });
+
+  it("returns deterministic slow_down on rapid repeated polling", async () => {
+    rpcMock
+      .mockResolvedValueOnce({
+        data: [
+          {
+            status: "pending",
+            access_token: null,
+            refresh_token: null,
+            expires_in: 900,
+            error: "authorization_pending",
+          },
+        ],
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: [
+          {
+            status: "error",
+            access_token: null,
+            refresh_token: null,
+            expires_in: 895,
+            error: "slow_down",
+          },
+        ],
+        error: null,
+      });
+
+    const firstResponse = await POST(
+      new Request("https://example.com/api/auth/device/token", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          device_code: "dev_rapid",
+          grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+        }),
+      })
+    );
+
+    const secondResponse = await POST(
+      new Request("https://example.com/api/auth/device/token", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          device_code: "dev_rapid",
+          grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+        }),
+      })
+    );
+
+    expect(firstResponse.status).toBe(400);
+    await expect(firstResponse.json()).resolves.toEqual({
+      error: "authorization_pending",
+      error_description: "The user has not yet authorized this device",
+      expires_in: 900,
+    });
+
+    expect(secondResponse.status).toBe(400);
+    await expect(secondResponse.json()).resolves.toEqual({
+      error: "slow_down",
+      error_description: "Polling too quickly. Increase your polling interval by 5 seconds.",
+      expires_in: 895,
+    });
+
+    expect(getTrustedClientIpMock).toHaveBeenCalledTimes(2);
+    expect(checkDeviceTokenRateLimitMock).toHaveBeenCalledTimes(2);
+    expect(rpcMock).toHaveBeenNthCalledWith(1, "check_device_code", {
+      p_device_code: "dev_rapid",
+    });
+    expect(rpcMock).toHaveBeenNthCalledWith(2, "check_device_code", {
+      p_device_code: "dev_rapid",
+    });
+  });
+});

--- a/src/app/api/auth/device/token/route.ts
+++ b/src/app/api/auth/device/token/route.ts
@@ -10,6 +10,8 @@
 import { NextResponse } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { logger } from "@/lib/logger";
+import { checkDeviceTokenRateLimit, getRateLimitHeaders } from "@/lib/rate-limit";
+import { getTrustedClientIp } from "@/lib/request-ip";
 
 const CORS_HEADERS = {
   "Access-Control-Allow-Origin": "*",
@@ -24,6 +26,22 @@ export function OPTIONS() {
 
 export async function POST(request: Request) {
   try {
+    const ip = getTrustedClientIp(request);
+    const rateLimit = await checkDeviceTokenRateLimit(ip);
+
+    if (!rateLimit.success) {
+      return NextResponse.json(
+        {
+          error: "rate_limit_exceeded",
+          error_description: "Too many token polling requests. Please slow down and retry.",
+        },
+        {
+          status: 429,
+          headers: { ...CORS_HEADERS, ...getRateLimitHeaders(rateLimit) },
+        }
+      );
+    }
+
     const body = await request.json().catch(() => ({}));
     const deviceCode = body.device_code;
     const grantType = body.grant_type;
@@ -90,13 +108,41 @@ export async function POST(request: Request) {
         );
 
       case "error":
-        // Map error codes to HTTP status
-        const statusCode = result.error === "slow_down" ? 400 : 
-                          result.error === "expired_token" ? 400 :
-                          result.error === "access_denied" ? 400 : 400;
+        if (result.error === "slow_down") {
+          return NextResponse.json(
+            {
+              error: "slow_down",
+              error_description: "Polling too quickly. Increase your polling interval by 5 seconds.",
+              expires_in: result.expires_in,
+            },
+            { status: 400, headers: CORS_HEADERS }
+          );
+        }
+
+        if (result.error === "expired_token") {
+          return NextResponse.json(
+            { error: "expired_token", error_description: "The device code has expired" },
+            { status: 400, headers: CORS_HEADERS }
+          );
+        }
+
+        if (result.error === "access_denied") {
+          return NextResponse.json(
+            { error: "access_denied", error_description: "The user denied the authorization request" },
+            { status: 400, headers: CORS_HEADERS }
+          );
+        }
+
+        if (result.error === "invalid_grant") {
+          return NextResponse.json(
+            { error: "invalid_grant", error_description: "Invalid device code" },
+            { status: 400, headers: CORS_HEADERS }
+          );
+        }
+
         return NextResponse.json(
-          { error: result.error },
-          { status: statusCode, headers: CORS_HEADERS }
+          { error: "server_error" },
+          { status: 500, headers: CORS_HEADERS }
         );
 
       default:

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -40,6 +40,22 @@ export const publicLimiter = new Ratelimit({
   prefix: "ratelimit:public",
 });
 
+// Rate limiter for device code creation: 10 requests per minute per IP
+export const deviceCodeLimiter = new Ratelimit({
+  redis,
+  limiter: Ratelimit.slidingWindow(10, "1 m"),
+  analytics: true,
+  prefix: "ratelimit:device-code",
+});
+
+// Rate limiter for device token polling: 30 requests per minute per IP
+export const deviceTokenLimiter = new Ratelimit({
+  redis,
+  limiter: Ratelimit.slidingWindow(30, "1 m"),
+  analytics: true,
+  prefix: "ratelimit:device-token",
+});
+
 export interface RateLimitResult {
   success: boolean;
   limit: number;
@@ -98,6 +114,54 @@ export async function checkPublicRateLimit(
     return {
       success: true,
       limit: 60,
+      remaining: 1,
+      reset: Date.now() + 60000,
+    };
+  }
+}
+
+/**
+ * Check rate limit for the device code endpoint by IP
+ */
+export async function checkDeviceCodeRateLimit(ip: string): Promise<RateLimitResult> {
+  try {
+    const result = await deviceCodeLimiter.limit(ip);
+
+    return {
+      success: result.success,
+      limit: result.limit,
+      remaining: result.remaining,
+      reset: result.reset,
+    };
+  } catch (error) {
+    logger.error("Device code rate limit check failed:", error);
+    return {
+      success: true,
+      limit: 10,
+      remaining: 1,
+      reset: Date.now() + 60000,
+    };
+  }
+}
+
+/**
+ * Check rate limit for the device token endpoint by IP
+ */
+export async function checkDeviceTokenRateLimit(ip: string): Promise<RateLimitResult> {
+  try {
+    const result = await deviceTokenLimiter.limit(ip);
+
+    return {
+      success: result.success,
+      limit: result.limit,
+      remaining: result.remaining,
+      reset: result.reset,
+    };
+  } catch (error) {
+    logger.error("Device token rate limit check failed:", error);
+    return {
+      success: true,
+      limit: 30,
       remaining: 1,
       reset: Date.now() + 60000,
     };

--- a/supabase/migrations/20260216180000_device_auth_polling_slowdown.sql
+++ b/supabase/migrations/20260216180000_device_auth_polling_slowdown.sql
@@ -1,0 +1,174 @@
+-- Add abuse-control state for device authorization polling
+-- and enforce RFC8628-style slow_down behavior.
+
+ALTER TABLE public.device_codes
+  ADD COLUMN IF NOT EXISTS last_polled_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS poll_interval_seconds INTEGER NOT NULL DEFAULT 5,
+  ADD COLUMN IF NOT EXISTS poll_slowdown_count INTEGER NOT NULL DEFAULT 0;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'device_codes_poll_interval_seconds_check'
+      AND conrelid = 'public.device_codes'::regclass
+  ) THEN
+    ALTER TABLE public.device_codes
+      ADD CONSTRAINT device_codes_poll_interval_seconds_check
+      CHECK (poll_interval_seconds >= 5 AND poll_interval_seconds <= 60);
+  END IF;
+END $$;
+
+DROP FUNCTION IF EXISTS public.check_device_code(TEXT);
+
+CREATE OR REPLACE FUNCTION public.check_device_code(p_device_code TEXT)
+RETURNS TABLE (
+  status TEXT,
+  access_token TEXT,
+  refresh_token TEXT,
+  expires_in INTEGER,
+  error TEXT
+) AS $$
+DECLARE
+  v_record RECORD;
+  v_access_token TEXT;
+  v_refresh_token TEXT;
+  v_session_id UUID;
+  v_now TIMESTAMPTZ := NOW();
+  v_new_poll_interval INTEGER;
+BEGIN
+  -- Lock row so polling metadata updates are deterministic.
+  SELECT dc.* INTO v_record
+  FROM public.device_codes dc
+  WHERE dc.device_code = p_device_code
+  FOR UPDATE;
+
+  -- Not found
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT
+      'error'::TEXT,
+      NULL::TEXT,
+      NULL::TEXT,
+      NULL::INTEGER,
+      'invalid_grant'::TEXT;
+    RETURN;
+  END IF;
+
+  -- Expired
+  IF v_record.expires_at < v_now THEN
+    UPDATE public.device_codes
+    SET status = 'expired'
+    WHERE id = v_record.id
+      AND status = 'pending';
+
+    RETURN QUERY SELECT
+      'error'::TEXT,
+      NULL::TEXT,
+      NULL::TEXT,
+      NULL::INTEGER,
+      'expired_token'::TEXT;
+    RETURN;
+  END IF;
+
+  -- Denied
+  IF v_record.status = 'denied' THEN
+    RETURN QUERY SELECT
+      'error'::TEXT,
+      NULL::TEXT,
+      NULL::TEXT,
+      NULL::INTEGER,
+      'access_denied'::TEXT;
+    RETURN;
+  END IF;
+
+  -- Already used/expired
+  IF v_record.status = 'expired' THEN
+    RETURN QUERY SELECT
+      'error'::TEXT,
+      NULL::TEXT,
+      NULL::TEXT,
+      NULL::INTEGER,
+      'expired_token'::TEXT;
+    RETURN;
+  END IF;
+
+  -- Still pending
+  IF v_record.status = 'pending' THEN
+    IF v_record.last_polled_at IS NOT NULL
+      AND v_record.last_polled_at + make_interval(secs => COALESCE(v_record.poll_interval_seconds, 5)) > v_now THEN
+      v_new_poll_interval := LEAST(COALESCE(v_record.poll_interval_seconds, 5) + 5, 60);
+
+      UPDATE public.device_codes
+      SET poll_interval_seconds = v_new_poll_interval,
+          poll_slowdown_count = COALESCE(poll_slowdown_count, 0) + 1
+      WHERE id = v_record.id;
+
+      RETURN QUERY SELECT
+        'error'::TEXT,
+        NULL::TEXT,
+        NULL::TEXT,
+        GREATEST(EXTRACT(EPOCH FROM (v_record.expires_at - v_now))::INTEGER, 0),
+        'slow_down'::TEXT;
+      RETURN;
+    END IF;
+
+    UPDATE public.device_codes
+    SET last_polled_at = v_now
+    WHERE id = v_record.id;
+
+    RETURN QUERY SELECT
+      'pending'::TEXT,
+      NULL::TEXT,
+      NULL::TEXT,
+      GREATEST(EXTRACT(EPOCH FROM (v_record.expires_at - v_now))::INTEGER, 0),
+      'authorization_pending'::TEXT;
+    RETURN;
+  END IF;
+
+  -- Authorized! Create session and return tokens
+  IF v_record.status = 'authorized' THEN
+    v_access_token := public.generate_secure_token('uni_');
+    v_refresh_token := public.generate_secure_token('unr_');
+
+    INSERT INTO public.api_sessions (
+      user_id,
+      access_token,
+      refresh_token,
+      client_name,
+      scope,
+      device_code_id
+    )
+    VALUES (
+      v_record.user_id,
+      v_access_token,
+      v_refresh_token,
+      v_record.client_name,
+      v_record.scope,
+      v_record.id
+    )
+    RETURNING id INTO v_session_id;
+
+    UPDATE public.device_codes
+    SET status = 'expired',
+        last_polled_at = v_now
+    WHERE id = v_record.id;
+
+    RETURN QUERY SELECT
+      'authorized'::TEXT,
+      v_access_token,
+      v_refresh_token,
+      NULL::INTEGER,
+      NULL::TEXT;
+    RETURN;
+  END IF;
+
+  -- Unknown state
+  RETURN QUERY SELECT
+    'error'::TEXT,
+    NULL::TEXT,
+    NULL::TEXT,
+    NULL::INTEGER,
+    'server_error'::TEXT;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;


### PR DESCRIPTION
## Summary
- add dedicated IP-based rate limits for `/api/auth/device/code` and `/api/auth/device/token`
- enforce deterministic RFC8628-style `slow_down` behavior in `check_device_code` via polling metadata and interval backoff
- add integration-style route tests for device auth abuse-control paths

## Validation
- pnpm -s lint
- pnpm -s typecheck
- pnpm -s test
- Supabase CLI migration apply check in isolated local project:
  - `supabase start` with baseline migrations + `20260216180000_device_auth_polling_slowdown.sql`

Closes #58

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth-related endpoints and a security-definer database function, changing runtime behavior and schema for device-code polling. While scoped, mistakes could cause false rate-limits or broken device login flows in production.
> 
> **Overview**
> Adds dedicated IP-based rate limiting to `POST /api/auth/device/code` and `POST /api/auth/device/token`, returning `429` with rate-limit headers and CORS when limits are exceeded.
> 
> Updates the device token polling path to return explicit RFC8628 error payloads (`slow_down`, `expired_token`, `access_denied`, `invalid_grant`) and treats unknown errors as `500`.
> 
> Introduces a Supabase migration that tracks polling metadata on `device_codes` and rewrites `check_device_code` to lock rows and deterministically enforce interval backoff (+5s up to 60s) on rapid polling. Adds Vitest route tests covering the new rate-limit and `slow_down` behaviors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e9dd035570c3908fe67b04c0105fc410a92adad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->