### PR TITLE
fix: harden stripe checkout route error handling

### DIFF
--- a/src/app/api/stripe/checkout/route.test.ts
+++ b/src/app/api/stripe/checkout/route.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { POST } from "./route";
+import { createClient } from "@/lib/supabase/server";
+import { createOrRetrieveCustomer, stripe } from "@/lib/stripe";
+import { logger } from "@/lib/logger";
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(),
+}));
+
+vi.mock("@/lib/stripe", () => ({
+  stripe: {
+    checkout: {
+      sessions: {
+        create: vi.fn(),
+      },
+    },
+  },
+  STRIPE_CONFIG: {
+    priceId: "price_test_123",
+  },
+  createOrRetrieveCustomer: vi.fn(),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    log: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+function mockAuthenticatedUser({
+  user,
+  subscription,
+}: {
+  user: { id: string; email?: string | null; user_metadata?: { full_name?: string | null } };
+  subscription: { plan: string; status: string } | null;
+}) {
+  const single = vi.fn().mockResolvedValue({ data: subscription, error: null });
+  const eq = vi.fn().mockReturnValue({ single });
+  const select = vi.fn().mockReturnValue({ eq });
+  const from = vi.fn().mockReturnValue({ select });
+
+  vi.mocked(createClient).mockResolvedValue({
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user },
+        error: null,
+      }),
+    },
+    from,
+  } as unknown as Awaited<ReturnType<typeof createClient>>);
+
+  return { from };
+}
+
+describe("POST /api/stripe/checkout", () => {
+  const createOrRetrieveCustomerMock = vi.mocked(createOrRetrieveCustomer);
+  const checkoutSessionCreateMock = vi.mocked(stripe.checkout.sessions.create);
+  const loggerErrorMock = vi.mocked(logger.error);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 400 when authenticated user has no email", async () => {
+    const { from } = mockAuthenticatedUser({
+      user: { id: "user_1", email: null, user_metadata: { full_name: "No Email User" } },
+      subscription: null,
+    });
+
+    const response = await POST();
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "invalid_request",
+      message: "Account email is required to start checkout",
+    });
+    expect(from).toHaveBeenCalledWith("subscriptions");
+    expect(createOrRetrieveCustomerMock).not.toHaveBeenCalled();
+    expect(checkoutSessionCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("returns controlled 500 response when Stripe checkout call fails", async () => {
+    mockAuthenticatedUser({
+      user: {
+        id: "user_2",
+        email: "pro@example.com",
+        user_metadata: { full_name: "Stripe Failure User" },
+      },
+      subscription: null,
+    });
+
+    createOrRetrieveCustomerMock.mockResolvedValue("cus_test_123");
+    const stripeError = new Error("Stripe API unavailable");
+    checkoutSessionCreateMock.mockRejectedValue(stripeError);
+
+    const response = await POST();
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      error: "Failed to create checkout session",
+    });
+    expect(createOrRetrieveCustomerMock).toHaveBeenCalledWith(
+      "user_2",
+      "pro@example.com",
+      "Stripe Failure User"
+    );
+    expect(loggerErrorMock).toHaveBeenCalledWith("Stripe checkout error:", stripeError);
+  });
+});

--- a/src/app/api/stripe/checkout/route.ts
+++ b/src/app/api/stripe/checkout/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { stripe, STRIPE_CONFIG, createOrRetrieveCustomer } from "@/lib/stripe";
+import { logger } from "@/lib/logger";
 
 export async function POST() {
   const supabase = await createClient();
@@ -22,35 +23,50 @@ export async function POST() {
     return NextResponse.json({ error: "Already subscribed to Pro" }, { status: 400 });
   }
 
-  // Get or create Stripe customer
-  const customerId = await createOrRetrieveCustomer(
-    user.id,
-    user.email!,
-    user.user_metadata?.full_name
-  );
+  if (!user.email) {
+    return NextResponse.json(
+      { error: "invalid_request", message: "Account email is required to start checkout" },
+      { status: 400 }
+    );
+  }
 
-  // Create checkout session
-  const session = await stripe.checkout.sessions.create({
-    customer: customerId,
-    mode: "subscription",
-    payment_method_types: ["card"],
-    line_items: [
-      {
-        price: STRIPE_CONFIG.priceId,
-        quantity: 1,
+  try {
+    // Get or create Stripe customer
+    const customerId = await createOrRetrieveCustomer(
+      user.id,
+      user.email,
+      user.user_metadata?.full_name
+    );
+
+    // Create checkout session
+    const session = await stripe.checkout.sessions.create({
+      customer: customerId,
+      mode: "subscription",
+      payment_method_types: ["card"],
+      line_items: [
+        {
+          price: STRIPE_CONFIG.priceId,
+          quantity: 1,
+        },
+      ],
+      success_url: `${process.env.NEXT_PUBLIC_SITE_URL}/bundles?upgraded=true`,
+      cancel_url: `${process.env.NEXT_PUBLIC_SITE_URL}/pricing?canceled=true`,
+      subscription_data: {
+        metadata: {
+          userId: user.id,
+        },
       },
-    ],
-    success_url: `${process.env.NEXT_PUBLIC_SITE_URL}/bundles?upgraded=true`,
-    cancel_url: `${process.env.NEXT_PUBLIC_SITE_URL}/pricing?canceled=true`,
-    subscription_data: {
       metadata: {
         userId: user.id,
       },
-    },
-    metadata: {
-      userId: user.id,
-    },
-  });
+    });
 
-  return NextResponse.json({ url: session.url });
+    return NextResponse.json({ url: session.url });
+  } catch (err) {
+    logger.error("Stripe checkout error:", err);
+    return NextResponse.json(
+      { error: "Failed to create checkout session" },
+      { status: 500 }
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- validate authenticated users have an email before attempting Stripe customer/session creation
- wrap checkout customer/session calls in explicit try/catch with controlled JSON 500 response
- add checkout route tests for missing-email validation and Stripe failure handling

## Validation
- pnpm -s lint
- pnpm -s typecheck
- pnpm -s test

Closes #59

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the Stripe checkout flow and changes API error responses; failures could block upgrades or alter client-side handling if consumers expect previous behavior.
> 
> **Overview**
> Hardens `POST /api/stripe/checkout` by rejecting authenticated users without an email (returns `400` with a specific JSON error) before any Stripe calls.
> 
> Wraps Stripe customer/session creation in a `try/catch`, logs failures via `logger.error`, and returns a controlled `500` JSON response instead of letting exceptions bubble.
> 
> Adds Vitest coverage for the missing-email path and for Stripe session creation failures (asserting status codes, response bodies, and that Stripe/customer creation isn’t called when it shouldn’t be).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 879ca24b7bf80739ba7db82dec9bf757ea3b2b25. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->