### PR TITLE
docs: document required CI coverage check

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,8 @@
 ## Test plan
 
 - [ ] Tested locally
+- [ ] Tests pass (`pnpm test`)
+- [ ] Coverage generated (`pnpm test:coverage`)
 - [ ] Types pass (`pnpm typecheck`)
 - [ ] Linting passes (`pnpm lint`)
 - [ ] Build succeeds (`pnpm build`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,10 +65,16 @@ Allowed types: `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `perf`, `tes
    ```bash
    pnpm lint
    pnpm typecheck
+   pnpm test
+   pnpm test:coverage
    pnpm build
    ```
 4. Open a PR against `main` with a clear description
 5. Fill out the PR template
+
+Required GitHub checks for merge:
+- `Lint, Typecheck & Build`
+- `Test Coverage`
 
 ## Project Structure
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -113,6 +113,27 @@ Open [http://localhost:3000](http://localhost:3000).
 - The `/` page is configured as dynamic so build does not require live DB access during prerender.
 - This keeps CI and local builds reliable in sandboxed/offline environments.
 
+## CI Checks
+
+Pull requests run two required GitHub Actions checks:
+
+- `Lint, Typecheck & Build`
+- `Test Coverage`
+
+To mirror CI locally:
+
+```bash
+pnpm lint
+pnpm typecheck
+pnpm test:coverage
+pnpm build
+```
+
+Coverage artifacts produced by CI:
+
+- `coverage/lcov.info`
+- `coverage/coverage-summary.json`
+
 ## How Semantic Search Works
 
 Unicon uses vector embeddings to understand the meaning of search queries:


### PR DESCRIPTION
## Summary
- add `pnpm test` and `pnpm test:coverage` to contributor pre-PR checks
- document required GitHub checks (`Lint, Typecheck & Build`, `Test Coverage`)
- update PR template test plan with coverage checklist item

## Validation
- pnpm -s typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates that don’t change runtime behavior; risk is limited to potentially outdated or incorrect process guidance.
> 
> **Overview**
> Clarifies the expected pre-merge quality gates by adding `pnpm test` and `pnpm test:coverage` to the PR template and contributor checklist.
> 
> Documents the required GitHub Actions checks for merge (including the new *Test Coverage* requirement) and adds guidance in `DEVELOPMENT.md` on mirroring CI locally plus which coverage artifacts CI produces.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e6ade4680bc8a6875a253cb76c488088c093d27. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->