### PR TITLE
Fix #74: fail-closed rate limiting when KV is unavailable

### DIFF
--- a/src/__tests__/rate-limit.test.ts
+++ b/src/__tests__/rate-limit.test.ts
@@ -1,11 +1,58 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { RateLimitResult } from "@/lib/rate-limit";
 
-// Import only the pure function — avoid importing the module top-level
-// since it initializes Redis with env vars
-describe("getRateLimitHeaders", () => {
-  it("should return correct header keys and string values", async () => {
-    // Dynamic import to avoid module-level Redis initialization
+const originalKvRestApiUrl = process.env.KV_REST_API_URL;
+const originalKvRestApiToken = process.env.KV_REST_API_TOKEN;
+
+describe("rate-limit helpers", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    delete process.env.KV_REST_API_URL;
+    delete process.env.KV_REST_API_TOKEN;
+  });
+
+  afterEach(() => {
+    if (typeof originalKvRestApiUrl === "string") {
+      process.env.KV_REST_API_URL = originalKvRestApiUrl;
+    } else {
+      delete process.env.KV_REST_API_URL;
+    }
+
+    if (typeof originalKvRestApiToken === "string") {
+      process.env.KV_REST_API_TOKEN = originalKvRestApiToken;
+    } else {
+      delete process.env.KV_REST_API_TOKEN;
+    }
+
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("returns all rate-limit headers with policy/status metadata", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-02-18T12:00:00.000Z"));
+
+    const { getRateLimitHeaders } = await import("@/lib/rate-limit");
+
+    const result: RateLimitResult = {
+      success: false,
+      limit: 60,
+      remaining: 0,
+      reset: Date.now() + 60_000,
+      policy: "fail-closed",
+      status: "degraded",
+    };
+
+    const headers = getRateLimitHeaders(result);
+
+    expect(headers["X-RateLimit-Limit"]).toBe("60");
+    expect(headers["X-RateLimit-Remaining"]).toBe("0");
+    expect(headers["X-RateLimit-Policy"]).toBe("fail-closed");
+    expect(headers["X-RateLimit-Status"]).toBe("degraded");
+    expect(headers["Retry-After"]).toBe("60");
+  });
+
+  it("defaults policy/status headers for normal Upstash responses", async () => {
     const { getRateLimitHeaders } = await import("@/lib/rate-limit");
 
     const result: RateLimitResult = {
@@ -17,8 +64,59 @@ describe("getRateLimitHeaders", () => {
 
     const headers = getRateLimitHeaders(result);
 
-    expect(headers["X-RateLimit-Limit"]).toBe("100");
-    expect(headers["X-RateLimit-Remaining"]).toBe("95");
-    expect(headers["X-RateLimit-Reset"]).toBe("1700000000");
+    expect(headers["X-RateLimit-Policy"]).toBe("upstash");
+    expect(headers["X-RateLimit-Status"]).toBe("normal");
+  });
+
+  it("fails closed for public and authenticated limit checks when KV is unavailable", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const {
+      checkPublicRateLimit,
+      checkRateLimit,
+      checkDeviceCodeRateLimit,
+      checkDeviceTokenRateLimit,
+    } = await import("@/lib/rate-limit");
+
+    await expect(checkPublicRateLimit("203.0.113.10")).resolves.toMatchObject({
+      success: false,
+      limit: 60,
+      remaining: 0,
+      policy: "fail-closed",
+      status: "degraded",
+    });
+
+    await expect(checkRateLimit("user_free", false)).resolves.toMatchObject({
+      success: false,
+      limit: 10,
+      remaining: 0,
+      policy: "fail-closed",
+      status: "degraded",
+    });
+
+    await expect(checkRateLimit("user_pro", true)).resolves.toMatchObject({
+      success: false,
+      limit: 100,
+      remaining: 0,
+      policy: "fail-closed",
+      status: "degraded",
+    });
+
+    await expect(checkDeviceCodeRateLimit("203.0.113.11")).resolves.toMatchObject({
+      success: false,
+      limit: 10,
+      remaining: 0,
+      policy: "fail-closed",
+      status: "degraded",
+    });
+
+    await expect(checkDeviceTokenRateLimit("203.0.113.12")).resolves.toMatchObject({
+      success: false,
+      limit: 30,
+      remaining: 0,
+      policy: "fail-closed",
+      status: "degraded",
+    });
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,6 +1,6 @@
 /**
  * Rate Limiting with Upstash Redis
- * 
+ *
  * Different limits for free vs Pro users:
  * - Free: 10 requests per minute
  * - Pro: 100 requests per minute
@@ -10,57 +10,116 @@ import { Ratelimit } from "@upstash/ratelimit";
 import { Redis } from "@upstash/redis";
 import { logger } from "@/lib/logger";
 
-// Initialize Redis client (uses Vercel KV env vars)
-const redis = new Redis({
-  url: process.env.KV_REST_API_URL!,
-  token: process.env.KV_REST_API_TOKEN!,
-});
+const RATE_LIMIT_WINDOW = "1 m";
+const RATE_LIMIT_RESET_MS = 60_000;
+
+const FREE_TIER_LIMIT = 10;
+const PRO_TIER_LIMIT = 100;
+const PUBLIC_LIMIT = 60;
+const DEVICE_CODE_LIMIT = 10;
+const DEVICE_TOKEN_LIMIT = 30;
+
+const kvRestApiUrl = process.env.KV_REST_API_URL;
+const kvRestApiToken = process.env.KV_REST_API_TOKEN;
+
+// Redis client is optional; missing config triggers fail-closed behavior.
+const redis = kvRestApiUrl && kvRestApiToken
+  ? new Redis({
+      url: kvRestApiUrl,
+      token: kvRestApiToken,
+    })
+  : null;
+
+let hasLoggedMissingConfig = false;
+
+function logMissingConfigOnce(): void {
+  if (hasLoggedMissingConfig || redis) {
+    return;
+  }
+
+  hasLoggedMissingConfig = true;
+  logger.warn(
+    "Rate limiting is running in fail-closed mode because KV_REST_API_URL/KV_REST_API_TOKEN are not configured."
+  );
+}
+
+function createLimiter(limit: number, prefix: string): Ratelimit | null {
+  if (!redis) {
+    return null;
+  }
+
+  return new Ratelimit({
+    redis,
+    limiter: Ratelimit.slidingWindow(limit, RATE_LIMIT_WINDOW),
+    analytics: true,
+    prefix,
+  });
+}
 
 // Rate limiter for free users: 10 requests per minute
-export const freeTierLimiter = new Ratelimit({
-  redis,
-  limiter: Ratelimit.slidingWindow(10, "1 m"),
-  analytics: true,
-  prefix: "ratelimit:free",
-});
+export const freeTierLimiter = createLimiter(FREE_TIER_LIMIT, "ratelimit:free");
 
-// Rate limiter for Pro users: 100 requests per minute  
-export const proTierLimiter = new Ratelimit({
-  redis,
-  limiter: Ratelimit.slidingWindow(100, "1 m"),
-  analytics: true,
-  prefix: "ratelimit:pro",
-});
+// Rate limiter for Pro users: 100 requests per minute
+export const proTierLimiter = createLimiter(PRO_TIER_LIMIT, "ratelimit:pro");
 
 // Rate limiter for public/anonymous API access: 60 requests per minute per IP
-export const publicLimiter = new Ratelimit({
-  redis,
-  limiter: Ratelimit.slidingWindow(60, "1 m"),
-  analytics: true,
-  prefix: "ratelimit:public",
-});
+export const publicLimiter = createLimiter(PUBLIC_LIMIT, "ratelimit:public");
 
 // Rate limiter for device code creation: 10 requests per minute per IP
-export const deviceCodeLimiter = new Ratelimit({
-  redis,
-  limiter: Ratelimit.slidingWindow(10, "1 m"),
-  analytics: true,
-  prefix: "ratelimit:device-code",
-});
+export const deviceCodeLimiter = createLimiter(DEVICE_CODE_LIMIT, "ratelimit:device-code");
 
 // Rate limiter for device token polling: 30 requests per minute per IP
-export const deviceTokenLimiter = new Ratelimit({
-  redis,
-  limiter: Ratelimit.slidingWindow(30, "1 m"),
-  analytics: true,
-  prefix: "ratelimit:device-token",
-});
+export const deviceTokenLimiter = createLimiter(DEVICE_TOKEN_LIMIT, "ratelimit:device-token");
+
+export type RateLimitPolicy = "upstash" | "fail-closed";
+export type RateLimitStatus = "normal" | "degraded";
 
 export interface RateLimitResult {
   success: boolean;
   limit: number;
   remaining: number;
   reset: number;
+  policy?: RateLimitPolicy;
+  status?: RateLimitStatus;
+}
+
+function failClosedResult(limit: number): RateLimitResult {
+  return {
+    success: false,
+    limit,
+    remaining: 0,
+    reset: Date.now() + RATE_LIMIT_RESET_MS,
+    policy: "fail-closed",
+    status: "degraded",
+  };
+}
+
+async function runRateLimitCheck(
+  limiter: Ratelimit | null,
+  key: string,
+  fallbackLimit: number,
+  errorLabel: string
+): Promise<RateLimitResult> {
+  if (!limiter) {
+    logMissingConfigOnce();
+    return failClosedResult(fallbackLimit);
+  }
+
+  try {
+    const result = await limiter.limit(key);
+
+    return {
+      success: result.success,
+      limit: result.limit,
+      remaining: result.remaining,
+      reset: result.reset,
+      policy: "upstash",
+      status: "normal",
+    };
+  } catch (error) {
+    logger.error(`${errorLabel} Entering fail-closed mode.`, error);
+    return failClosedResult(fallbackLimit);
+  }
 }
 
 /**
@@ -71,26 +130,8 @@ export async function checkRateLimit(
   isPro: boolean
 ): Promise<RateLimitResult> {
   const limiter = isPro ? proTierLimiter : freeTierLimiter;
-  
-  try {
-    const result = await limiter.limit(userId);
-    
-    return {
-      success: result.success,
-      limit: result.limit,
-      remaining: result.remaining,
-      reset: result.reset,
-    };
-  } catch (error) {
-    // If rate limiting fails (e.g., Redis unavailable), allow the request
-    logger.error("Rate limit check failed:", error);
-    return {
-      success: true,
-      limit: isPro ? 100 : 10,
-      remaining: 1,
-      reset: Date.now() + 60000,
-    };
-  }
+  const fallbackLimit = isPro ? PRO_TIER_LIMIT : FREE_TIER_LIMIT;
+  return runRateLimitCheck(limiter, userId, fallbackLimit, "Rate limit check failed.");
 }
 
 /**
@@ -99,82 +140,45 @@ export async function checkRateLimit(
 export async function checkPublicRateLimit(
   ip: string
 ): Promise<RateLimitResult> {
-  try {
-    const result = await publicLimiter.limit(ip);
-
-    return {
-      success: result.success,
-      limit: result.limit,
-      remaining: result.remaining,
-      reset: result.reset,
-    };
-  } catch (error) {
-    // If rate limiting fails (e.g., Redis unavailable), allow the request
-    logger.error("Public rate limit check failed:", error);
-    return {
-      success: true,
-      limit: 60,
-      remaining: 1,
-      reset: Date.now() + 60000,
-    };
-  }
+  return runRateLimitCheck(publicLimiter, ip, PUBLIC_LIMIT, "Public rate limit check failed.");
 }
 
 /**
  * Check rate limit for the device code endpoint by IP
  */
 export async function checkDeviceCodeRateLimit(ip: string): Promise<RateLimitResult> {
-  try {
-    const result = await deviceCodeLimiter.limit(ip);
-
-    return {
-      success: result.success,
-      limit: result.limit,
-      remaining: result.remaining,
-      reset: result.reset,
-    };
-  } catch (error) {
-    logger.error("Device code rate limit check failed:", error);
-    return {
-      success: true,
-      limit: 10,
-      remaining: 1,
-      reset: Date.now() + 60000,
-    };
-  }
+  return runRateLimitCheck(
+    deviceCodeLimiter,
+    ip,
+    DEVICE_CODE_LIMIT,
+    "Device code rate limit check failed."
+  );
 }
 
 /**
  * Check rate limit for the device token endpoint by IP
  */
 export async function checkDeviceTokenRateLimit(ip: string): Promise<RateLimitResult> {
-  try {
-    const result = await deviceTokenLimiter.limit(ip);
-
-    return {
-      success: result.success,
-      limit: result.limit,
-      remaining: result.remaining,
-      reset: result.reset,
-    };
-  } catch (error) {
-    logger.error("Device token rate limit check failed:", error);
-    return {
-      success: true,
-      limit: 30,
-      remaining: 1,
-      reset: Date.now() + 60000,
-    };
-  }
+  return runRateLimitCheck(
+    deviceTokenLimiter,
+    ip,
+    DEVICE_TOKEN_LIMIT,
+    "Device token rate limit check failed."
+  );
 }
 
 /**
  * Get rate limit headers for response
  */
 export function getRateLimitHeaders(result: RateLimitResult): Record<string, string> {
+  const retryAfterSeconds = Math.max(0, Math.ceil((result.reset - Date.now()) / 1000));
+
   return {
     "X-RateLimit-Limit": String(result.limit),
     "X-RateLimit-Remaining": String(result.remaining),
     "X-RateLimit-Reset": String(result.reset),
+    "X-RateLimit-Policy": result.policy ?? "upstash",
+    "X-RateLimit-Status": result.status ?? "normal",
+    "Retry-After": String(retryAfterSeconds),
   };
 }


### PR DESCRIPTION
## Summary
- make rate limiting fail closed when KV/Redis is unavailable or limiter calls fail
- add explicit rate-limit metadata headers (`X-RateLimit-Policy`, `X-RateLimit-Status`, `Retry-After`)
- add tests for failure-path behavior across public and authenticated/device limit checks

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test src/__tests__/rate-limit.test.ts src/app/api/auth/device/code/route.test.ts src/app/api/auth/device/token/route.test.ts src/app/api/mcp/route.test.ts

Closes #74

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes enforcement behavior from allow-on-failure to deny-on-failure across multiple API paths; misconfiguration or unexpected Upstash issues could cause elevated 429s.
> 
> **Overview**
> Rate limiting is changed to **fail closed** when `KV_REST_API_URL`/`KV_REST_API_TOKEN` are missing or when Upstash limiter calls throw, returning `success: false` (429 path) instead of allowing requests.
> 
> `src/lib/rate-limit.ts` now creates limiters only when KV config exists, centralizes checks via `runRateLimitCheck`, and attaches *metadata* (`policy`/`status`) plus a computed `Retry-After` header in `getRateLimitHeaders`. Tests were expanded to validate the new headers and that all limiter entry points (public, user, device code/token) fail closed and only warn once when KV is unconfigured.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f9c131bfb9a8c59c3f42abbfba99f7bb97d170e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->