### PR TITLE
Fix #75: bind invite acceptance to intended email identity

### DIFF
--- a/src/app/api/invites/[token]/route.test.ts
+++ b/src/app/api/invites/[token]/route.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { POST } from "./route";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(),
+}));
+
+describe("POST /api/invites/[token]", () => {
+  const createClientMock = vi.mocked(createClient);
+  const createAdminClientMock = vi.mocked(createAdminClient);
+  const getUserMock = vi.fn();
+  const rpcMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    getUserMock.mockResolvedValue({
+      data: { user: { id: "user_1", email: "Invitee@Example.com" } },
+      error: null,
+    });
+
+    createClientMock.mockResolvedValue({
+      auth: { getUser: getUserMock },
+    } as unknown as Awaited<ReturnType<typeof createClient>>);
+
+    rpcMock.mockResolvedValue({
+      data: [
+        {
+          success: true,
+          error: null,
+          team_id: "team_1",
+          team_name: "Team One",
+        },
+      ],
+      error: null,
+    });
+
+    createAdminClientMock.mockReturnValue({
+      rpc: rpcMock,
+    } as unknown as ReturnType<typeof createAdminClient>);
+  });
+
+  it("passes normalized authenticated email to the invite acceptance RPC", async () => {
+    const response = await POST(new Request("https://example.com/api/invites/inv_token"), {
+      params: Promise.resolve({ token: "inv_token" }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(rpcMock).toHaveBeenCalledWith("accept_team_invite_atomic", {
+      p_token: "inv_token",
+      p_user_id: "user_1",
+      p_user_email: "invitee@example.com",
+    });
+  });
+
+  it("returns 403 when invite email does not match authenticated user email", async () => {
+    rpcMock.mockResolvedValue({
+      data: [
+        {
+          success: false,
+          error: "Invite email does not match authenticated user",
+          team_id: null,
+          team_name: null,
+        },
+      ],
+      error: null,
+    });
+
+    const response = await POST(new Request("https://example.com/api/invites/inv_token"), {
+      params: Promise.resolve({ token: "inv_token" }),
+    });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      error: "Invite email does not match authenticated user",
+    });
+  });
+
+  it("returns 403 when authenticated email does not match profile email", async () => {
+    rpcMock.mockResolvedValue({
+      data: [
+        {
+          success: false,
+          error: "Authenticated user email does not match profile email",
+          team_id: null,
+          team_name: null,
+        },
+      ],
+      error: null,
+    });
+
+    const response = await POST(new Request("https://example.com/api/invites/inv_token"), {
+      params: Promise.resolve({ token: "inv_token" }),
+    });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      error: "Authenticated user email does not match profile email",
+    });
+  });
+
+  it("returns 403 when authenticated user does not have an email", async () => {
+    getUserMock.mockResolvedValue({
+      data: { user: { id: "user_1", email: null } },
+      error: null,
+    });
+
+    const response = await POST(new Request("https://example.com/api/invites/inv_token"), {
+      params: Promise.resolve({ token: "inv_token" }),
+    });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      error: "Your account must have a verified email to accept this invite",
+    });
+    expect(createAdminClientMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/invites/[token]/route.ts
+++ b/src/app/api/invites/[token]/route.ts
@@ -28,10 +28,19 @@ export async function POST(_request: Request, { params }: RouteParams) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
+  const normalizedUserEmail = user.email?.trim().toLowerCase();
+  if (!normalizedUserEmail) {
+    return NextResponse.json(
+      { error: "Your account must have a verified email to accept this invite" },
+      { status: 403 }
+    );
+  }
+
   const admin = createAdminClient();
   const { data, error } = await admin.rpc("accept_team_invite_atomic", {
     p_token: token,
     p_user_id: user.id,
+    p_user_email: normalizedUserEmail,
   });
 
   if (error) {
@@ -67,5 +76,8 @@ function mapInviteErrorToStatus(error: string): number {
   if (error === "Team is at maximum capacity") return 409;
   if (error === "You're already a member of this team") return 409;
   if (error === "Team not found") return 404;
+  if (error === "Invite email does not match authenticated user") return 403;
+  if (error === "Authenticated user email is required") return 403;
+  if (error === "Authenticated user email does not match profile email") return 403;
   return 400;
 }

--- a/supabase/migrations/20260218182000_bind_invite_acceptance_to_email.sql
+++ b/supabase/migrations/20260218182000_bind_invite_acceptance_to_email.sql
@@ -1,0 +1,134 @@
+-- Bind invite acceptance to invited email identity.
+-- Prevents invite token redemption by authenticated users with mismatched emails.
+
+DROP FUNCTION IF EXISTS public.accept_team_invite_atomic(TEXT, UUID);
+
+CREATE OR REPLACE FUNCTION public.accept_team_invite_atomic(
+  p_token TEXT,
+  p_user_id UUID,
+  p_user_email TEXT
+)
+RETURNS TABLE (
+  success BOOLEAN,
+  error TEXT,
+  team_id UUID,
+  team_name TEXT
+) AS $$
+DECLARE
+  v_invite public.team_invites%ROWTYPE;
+  v_team public.teams%ROWTYPE;
+  v_member_count INTEGER;
+  v_profile_email TEXT;
+  v_normalized_invite_email TEXT;
+  v_normalized_profile_email TEXT;
+  v_normalized_user_email TEXT;
+BEGIN
+  -- Lock invite row so status transitions are serialized per token.
+  SELECT * INTO v_invite
+  FROM public.team_invites
+  WHERE token = p_token
+    AND status = 'pending'
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT FALSE, 'Invite not found or already used'::TEXT, NULL::UUID, NULL::TEXT;
+    RETURN;
+  END IF;
+
+  -- Lock team row so member count + insert is serialized per team.
+  SELECT * INTO v_team
+  FROM public.teams
+  WHERE id = v_invite.team_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT FALSE, 'Team not found'::TEXT, NULL::UUID, NULL::TEXT;
+    RETURN;
+  END IF;
+
+  IF v_invite.expires_at < NOW() THEN
+    UPDATE public.team_invites
+    SET status = 'expired'
+    WHERE id = v_invite.id;
+
+    RETURN QUERY SELECT FALSE, 'This invite has expired'::TEXT, NULL::UUID, NULL::TEXT;
+    RETURN;
+  END IF;
+
+  SELECT email INTO v_profile_email
+  FROM public.profiles
+  WHERE id = p_user_id;
+
+  v_normalized_invite_email := lower(trim(v_invite.email));
+  v_normalized_profile_email := lower(trim(coalesce(v_profile_email, '')));
+  v_normalized_user_email := lower(trim(coalesce(p_user_email, '')));
+
+  IF v_normalized_profile_email = '' THEN
+    RETURN QUERY SELECT FALSE, 'Authenticated user email is required'::TEXT, NULL::UUID, NULL::TEXT;
+    RETURN;
+  END IF;
+
+  IF v_normalized_user_email = '' OR v_normalized_user_email <> v_normalized_profile_email THEN
+    RETURN QUERY SELECT FALSE, 'Authenticated user email does not match profile email'::TEXT, NULL::UUID, NULL::TEXT;
+    RETURN;
+  END IF;
+
+  IF v_normalized_invite_email <> v_normalized_profile_email THEN
+    RETURN QUERY SELECT FALSE, 'Invite email does not match authenticated user'::TEXT, NULL::UUID, NULL::TEXT;
+    RETURN;
+  END IF;
+
+  -- If user is already a member, mirror existing behavior:
+  -- mark invite accepted and return a conflict message.
+  IF EXISTS (
+    SELECT 1
+    FROM public.team_members
+    WHERE team_id = v_invite.team_id
+      AND user_id = p_user_id
+  ) THEN
+    UPDATE public.team_invites
+    SET status = 'accepted'
+    WHERE id = v_invite.id;
+
+    RETURN QUERY SELECT FALSE, 'You''re already a member of this team'::TEXT, v_team.id, v_team.name;
+    RETURN;
+  END IF;
+
+  SELECT COUNT(*)::INTEGER INTO v_member_count
+  FROM public.team_members
+  WHERE team_id = v_invite.team_id;
+
+  IF v_member_count >= v_team.max_members THEN
+    RETURN QUERY SELECT FALSE, 'Team is at maximum capacity'::TEXT, v_team.id, v_team.name;
+    RETURN;
+  END IF;
+
+  BEGIN
+    INSERT INTO public.team_members (team_id, user_id, role)
+    VALUES (
+      v_invite.team_id,
+      p_user_id,
+      CASE
+        WHEN v_invite.role = 'owner' THEN 'member'::public.team_role
+        ELSE v_invite.role
+      END
+    );
+  EXCEPTION
+    WHEN unique_violation THEN
+      UPDATE public.team_invites
+      SET status = 'accepted'
+      WHERE id = v_invite.id;
+
+      RETURN QUERY SELECT FALSE, 'You''re already a member of this team'::TEXT, v_team.id, v_team.name;
+      RETURN;
+  END;
+
+  UPDATE public.team_invites
+  SET status = 'accepted'
+  WHERE id = v_invite.id;
+
+  RETURN QUERY SELECT TRUE, NULL::TEXT, v_team.id, v_team.name;
+END;
+$$ LANGUAGE plpgsql;
+
+GRANT EXECUTE ON FUNCTION public.accept_team_invite_atomic(TEXT, UUID, TEXT) TO authenticated;


### PR DESCRIPTION
## Summary
- require normalized authenticated email on invite acceptance route and pass it into the RPC call
- harden `accept_team_invite_atomic` to bind invite redemption to the authenticated user profile email
- add route tests for match and mismatch `403` cases

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test 'src/app/api/invites/[token]/route.test.ts' 'src/app/api/teams/[teamId]/invites/[inviteId]/route.test.ts'

Closes #75

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the invite-acceptance security boundary and replaces a database function signature/behavior, which could block legitimate acceptances if email/profile data is inconsistent.
> 
> **Overview**
> **Prevents invite token redemption by the wrong user/email.** The invite acceptance route now requires a normalized authenticated email, returns `403` when missing, and passes the email into `accept_team_invite_atomic`.
> 
> The Supabase migration replaces `accept_team_invite_atomic` with a 3-arg version that normalizes and validates `invite.email`, `profiles.email`, and the passed auth email, returning explicit `403`-mapped errors on mismatches. Adds Vitest coverage for the normalized-email RPC call and the new `403` mismatch/missing-email cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ce8b6ec56614c675f1c2e501d9fcbd3a443c22b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->