### PR TITLE
Fix #76: align semantic cache payloads with hasMore pagination metadata

### DIFF
--- a/src/app/api/admin/warm-cache/route.test.ts
+++ b/src/app/api/admin/warm-cache/route.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { POST } from "./route";
+import { db } from "@/lib/db";
+import {
+  embeddingToVectorString,
+  generateSearchCacheKey,
+  getEmbedding,
+  setCachedSearchResults,
+} from "@/lib/ai";
+import { requireAdminAuth } from "@/lib/auth/admin";
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    all: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/ai", () => ({
+  getEmbedding: vi.fn(),
+  embeddingToVectorString: vi.fn(),
+  generateSearchCacheKey: vi.fn(),
+  setCachedSearchResults: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/admin", () => ({
+  requireAdminAuth: vi.fn(),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    log: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+function makeSemanticRow(index: number) {
+  return {
+    id: `icon-${index}`,
+    name: `Icon ${index}`,
+    normalizedName: `icon-${index}`,
+    sourceId: "lucide",
+    category: "general",
+    tags: "[]",
+    viewBox: "0 0 24 24",
+    content: "<path d='M1 1h22v22H1z'/>",
+    pathData: null,
+    defaultStroke: 1,
+    defaultFill: 0,
+    strokeWidth: "2",
+    brandColor: null,
+    distance: index,
+  };
+}
+
+describe("POST /api/admin/warm-cache", () => {
+  const dbAllMock = vi.mocked(db.all);
+  const getEmbeddingMock = vi.mocked(getEmbedding);
+  const embeddingToVectorStringMock = vi.mocked(embeddingToVectorString);
+  const generateSearchCacheKeyMock = vi.mocked(generateSearchCacheKey);
+  const setCachedSearchResultsMock = vi.mocked(setCachedSearchResults);
+  const requireAdminAuthMock = vi.mocked(requireAdminAuth);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    requireAdminAuthMock.mockReturnValue(null);
+    getEmbeddingMock.mockResolvedValue([0.1, 0.2, 0.3]);
+    embeddingToVectorStringMock.mockReturnValue("[0.1,0.2,0.3]");
+    generateSearchCacheKeyMock.mockReturnValue("search:arrow:all:50:0");
+
+    const rows = Array.from({ length: 51 }, (_, index) => makeSemanticRow(index + 1));
+    dbAllMock.mockResolvedValue(rows);
+  });
+
+  it("stores hasMore metadata for warmed semantic cache payloads", async () => {
+    const response = await POST(
+      new Request("https://example.com/api/admin/warm-cache?queries=arrow") as never
+    );
+
+    expect(response.status).toBe(200);
+    expect(setCachedSearchResultsMock).toHaveBeenCalledWith(
+      "search:arrow:all:50:0",
+      expect.objectContaining({
+        hasMore: true,
+        searchType: "semantic",
+      })
+    );
+
+    const cachedPayload = setCachedSearchResultsMock.mock.calls[0]?.[1] as
+      | { icons?: unknown[]; hasMore?: boolean }
+      | undefined;
+    expect(cachedPayload?.icons).toHaveLength(50);
+    expect(cachedPayload?.hasMore).toBe(true);
+  });
+});

--- a/src/app/api/admin/warm-cache/route.ts
+++ b/src/app/api/admin/warm-cache/route.ts
@@ -5,6 +5,7 @@ import { sql } from "drizzle-orm";
 import type { IconData } from "@/types/icon";
 import { logger } from "@/lib/logger";
 import { requireAdminAuth } from "@/lib/auth/admin";
+import { sliceForPagination } from "@/lib/api/pagination";
 
 /**
  * Popular search queries to pre-warm the cache.
@@ -80,11 +81,11 @@ export async function POST(request: NextRequest) {
           FROM icons
           WHERE embedding IS NOT NULL
           ORDER BY distance ASC
-          LIMIT ${limit} OFFSET ${offset}
+          LIMIT ${limit + 1} OFFSET ${offset}
         `);
 
         // Convert to IconData format
-        const icons: IconData[] = (semanticResults as Array<Record<string, unknown>>).map((row) => {
+        const iconRows: IconData[] = (semanticResults as Array<Record<string, unknown>>).map((row) => {
           let tags: string[];
           try {
             tags = typeof row.tags === "string" ? JSON.parse(row.tags) : (row.tags ?? []);
@@ -115,11 +116,13 @@ export async function POST(request: NextRequest) {
             brandColor: row.brandColor as string | null,
           };
         });
+        const { items: icons, hasMore } = sliceForPagination(iconRows, limit);
 
         // Cache the results
         const cacheKey = generateSearchCacheKey({ query, limit, offset });
         setCachedSearchResults(cacheKey, {
           icons,
+          hasMore,
           searchType: "semantic",
         });
 

--- a/src/app/api/icons/route.test.ts
+++ b/src/app/api/icons/route.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { GET } from "./route";
+import { db } from "@/lib/db";
+import { checkPublicRateLimit } from "@/lib/rate-limit";
+import { getCachedSearchResults, setCachedSearchResults } from "@/lib/ai";
+
+const semanticCache = vi.hoisted(() => new Map<string, unknown>());
+
+vi.mock("@/lib/queries", () => ({
+  searchIcons: vi.fn(),
+  getIconsByNames: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    all: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/ai", () => ({
+  getEmbedding: vi.fn().mockResolvedValue([0.1, 0.2, 0.3]),
+  embeddingToVectorString: vi.fn().mockReturnValue("[0.1,0.2,0.3]"),
+  expandQueryWithAI: vi.fn().mockResolvedValue(null),
+  generateSearchCacheKey: vi.fn(
+    (params: { query: string; sourceId?: string; limit: number; offset: number }) =>
+      `search:${params.query.toLowerCase().trim()}:${params.sourceId || "all"}:${params.limit}:${params.offset}`
+  ),
+  getCachedSearchResults: vi.fn((cacheKey: string) => (semanticCache.get(cacheKey) as unknown) ?? null),
+  setCachedSearchResults: vi.fn((cacheKey: string, data: unknown) => {
+    semanticCache.set(cacheKey, data);
+  }),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    log: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/analytics", () => ({
+  logSearch: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  checkPublicRateLimit: vi.fn(),
+  getRateLimitHeaders: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock("@/lib/request-ip", () => ({
+  getTrustedClientIp: vi.fn().mockReturnValue("203.0.113.10"),
+}));
+
+vi.mock("@vercel/functions", () => ({
+  waitUntil: vi.fn(),
+}));
+
+function makeSemanticRow(index: number) {
+  return {
+    id: `icon-${index}`,
+    name: `Icon ${index}`,
+    normalizedName: `icon-${index}`,
+    sourceId: "lucide",
+    category: "general",
+    tags: "[]",
+    viewBox: "0 0 24 24",
+    content: "<path d='M1 1h22v22H1z'/>",
+    pathData: null,
+    defaultStroke: 1,
+    defaultFill: 0,
+    strokeWidth: "2",
+    brandColor: null,
+    distance: index,
+  };
+}
+
+describe("GET /api/icons semantic cache pagination", () => {
+  const dbAllMock = vi.mocked(db.all);
+  const checkPublicRateLimitMock = vi.mocked(checkPublicRateLimit);
+  const getCachedSearchResultsMock = vi.mocked(getCachedSearchResults);
+  const setCachedSearchResultsMock = vi.mocked(setCachedSearchResults);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    semanticCache.clear();
+
+    checkPublicRateLimitMock.mockResolvedValue({
+      success: true,
+      limit: 60,
+      remaining: 59,
+      reset: Date.now() + 60_000,
+    });
+
+    dbAllMock.mockResolvedValue([makeSemanticRow(1), makeSemanticRow(2), makeSemanticRow(3)]);
+  });
+
+  it("stores hasMore in cache and returns consistent hasMore on cache hits", async () => {
+    const request = new Request("https://example.com/api/icons?q=arrow&limit=2&offset=0");
+
+    const firstResponse = await GET(request as never);
+    expect(firstResponse.status).toBe(200);
+    await expect(firstResponse.json()).resolves.toMatchObject({
+      hasMore: true,
+      searchType: "semantic",
+    });
+
+    expect(setCachedSearchResultsMock).toHaveBeenCalledWith(
+      "search:arrow:all:2:0",
+      expect.objectContaining({
+        hasMore: true,
+        searchType: "semantic",
+      })
+    );
+
+    dbAllMock.mockClear();
+    const secondResponse = await GET(request as never);
+    expect(secondResponse.status).toBe(200);
+    await expect(secondResponse.json()).resolves.toMatchObject({
+      hasMore: true,
+      searchType: "semantic",
+    });
+    expect(dbAllMock).not.toHaveBeenCalled();
+  });
+
+  it("defaults legacy cache entries without hasMore to hasMore=false", async () => {
+    semanticCache.set("search:arrow:all:2:0", {
+      icons: [makeSemanticRow(1)],
+      searchType: "semantic",
+    });
+
+    const request = new Request("https://example.com/api/icons?q=arrow&limit=2&offset=0");
+    const response = await GET(request as never);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      hasMore: false,
+      searchType: "semantic",
+    });
+
+    expect(getCachedSearchResultsMock).toHaveBeenCalledWith("search:arrow:all:2:0");
+    expect(dbAllMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/icons/route.ts
+++ b/src/app/api/icons/route.ts
@@ -206,10 +206,21 @@ async function aiSemanticSearch(
     limit,
     offset,
   });
-  const cached = getCachedSearchResults<{ icons: IconData[]; hasMore: boolean; searchType: string; expandedQuery?: string }>(cacheKey);
+  const cached = getCachedSearchResults<{
+    icons: IconData[];
+    hasMore?: boolean;
+    searchType: string;
+    expandedQuery?: string;
+  }>(cacheKey);
   if (cached) {
     logger.log(`Cache hit for search: "${query}"`);
-    return { ...cached, cacheHit: true };
+    return {
+      icons: cached.icons,
+      hasMore: cached.hasMore ?? false,
+      searchType: cached.searchType,
+      ...(cached.expandedQuery ? { expandedQuery: cached.expandedQuery } : {}),
+      cacheHit: true,
+    };
   }
   // Start AI expansion and original embedding in parallel for faster response
   const aiExpansionPromise = process.env.ANTHROPIC_API_KEY
@@ -338,7 +349,12 @@ async function aiSemanticSearch(
   }
 
   // Cache the result (without cacheHit flag)
-  const cacheData = { icons: result.icons, searchType: result.searchType, expandedQuery: result.expandedQuery };
+  const cacheData = {
+    icons: result.icons,
+    hasMore: result.hasMore,
+    searchType: result.searchType,
+    expandedQuery: result.expandedQuery,
+  };
   setCachedSearchResults(cacheKey, cacheData);
 
   return result;


### PR DESCRIPTION
## Summary
- include `hasMore` in semantic cache payloads written by `/api/icons`
- include `hasMore` in warm-cache prepopulation payloads and align warm-cache DB fetch to `limit + 1`
- add cache-hit pagination regression tests for `/api/icons` and warm-cache payload tests
- add backward-compatible fallback for legacy cache entries missing `hasMore`

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test 'src/app/api/icons/route.test.ts' 'src/app/api/admin/warm-cache/route.test.ts'

Closes #76

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, well-tested change to cache payload shape and pagination metadata; main risk is minor behavior differences for consumers relying on previous cached entries.
> 
> **Overview**
> Aligns semantic-search caching with pagination by persisting `hasMore` alongside cached results.
> 
> `/api/icons` now reads `hasMore` from cache (defaulting to `false` for legacy entries) and writes `hasMore` when storing semantic results. The admin `/api/admin/warm-cache` prewarmer now fetches `limit + 1`, uses `sliceForPagination`, and stores `hasMore` in warmed cache entries.
> 
> Adds Vitest coverage to ensure cache hits return consistent `hasMore` and warm-cache writes correct pagination metadata.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f79dc2fec01c2cf8e84d5f046988a928368edbfc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->