### PR TITLE
Fix #77: reduce homepage DB load via runtime caching

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,18 +1,37 @@
 import { MetallicIconBrowser } from "@/components/icons/metallic-icon-browser";
 import { HomeHeader } from "@/components/home-header";
 import { searchIcons, getTotalIconCount, getIconCountBySource, getCategories } from "@/lib/queries";
+import { unstable_cache } from "next/cache";
 
 // force-dynamic: CI/build environment has no DB credentials, so prerendering would fail.
-// Caching is handled at the API/CDN layer instead (see /api/icons cache headers).
+// We still cache homepage DB reads at runtime using unstable_cache below.
 export const dynamic = "force-dynamic";
 
+const getCachedHomePageData = unstable_cache(
+  async () => {
+    const [icons, totalCount, countBySource, categories] = await Promise.all([
+      searchIcons({ limit: 320 }),
+      getTotalIconCount(),
+      getIconCountBySource(),
+      getCategories(),
+    ]);
+
+    return {
+      icons,
+      totalCount,
+      countBySource,
+      categories,
+    };
+  },
+  ["home-page-data-v1"],
+  {
+    revalidate: 60 * 15,
+    tags: ["home-page-data"],
+  }
+);
+
 export default async function Home() {
-  const [icons, totalCount, countBySource, categories] = await Promise.all([
-    searchIcons({ limit: 320 }),
-    getTotalIconCount(),
-    getIconCountBySource(),
-    getCategories(),
-  ]);
+  const { icons, totalCount, countBySource, categories } = await getCachedHomePageData();
 
   return (
     <>


### PR DESCRIPTION
## Summary
- keep homepage `force-dynamic` to avoid CI/build-time DB dependency
- wrap homepage DB reads in `unstable_cache` with 15-minute runtime revalidation
- preserve existing homepage UI/UX while reducing repeated DB work for high-traffic repeated hits

## Validation
- pnpm lint
- pnpm typecheck

Closes #77

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated change to homepage data fetching that only affects freshness/caching behavior and doesn’t touch auth or data writes.
> 
> **Overview**
> Reduces repeated homepage database load by wrapping the initial icon search and related counts/categories queries in Next.js `unstable_cache`, with a 15-minute `revalidate` window and cache tags.
> 
> Keeps `dynamic = "force-dynamic"` (avoiding build-time DB access) while switching `Home` to fetch a single cached bundle of data instead of executing the queries on every request.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f61695a43a7e968721f401dbe2fe62b5cbb3924f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->