### PR TITLE
Fix #78: increase critical route coverage and enforce CI baseline

### DIFF
--- a/src/app/api/health/route.test.ts
+++ b/src/app/api/health/route.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GET } from "./route";
+import { db } from "@/lib/db";
+import { getCacheStats } from "@/lib/ai";
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    all: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/ai", () => ({
+  getCacheStats: vi.fn(),
+}));
+
+describe("GET /api/health", () => {
+  const dbAllMock = vi.mocked(db.all);
+  const getCacheStatsMock = vi.mocked(getCacheStats);
+  const originalAiGatewayKey = process.env.AI_GATEWAY_API_KEY;
+  const originalAnthropicKey = process.env.ANTHROPIC_API_KEY;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    getCacheStatsMock.mockReturnValue({
+      searchResults: { size: 10, maxSize: 100 },
+      embeddings: { size: 50, maxSize: 1000 },
+      queryExpansions: { size: 20, maxSize: 1000 },
+    });
+  });
+
+  afterEach(() => {
+    if (typeof originalAiGatewayKey === "string") {
+      process.env.AI_GATEWAY_API_KEY = originalAiGatewayKey;
+    } else {
+      delete process.env.AI_GATEWAY_API_KEY;
+    }
+
+    if (typeof originalAnthropicKey === "string") {
+      process.env.ANTHROPIC_API_KEY = originalAnthropicKey;
+    } else {
+      delete process.env.ANTHROPIC_API_KEY;
+    }
+  });
+
+  it("returns healthy when DB, cache, and AI config checks pass", async () => {
+    process.env.AI_GATEWAY_API_KEY = "gateway-key";
+    process.env.ANTHROPIC_API_KEY = "anthropic-key";
+
+    dbAllMock
+      .mockResolvedValueOnce([{ count: 100 }])
+      .mockResolvedValueOnce([{ count: 80 }]);
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      status: "healthy",
+      database: {
+        status: "healthy",
+        connected: true,
+        icons: {
+          total: 100,
+          withEmbeddings: 80,
+          percentage: 80,
+        },
+      },
+      ai: {
+        status: "healthy",
+        openai: { configured: true, status: "ready" },
+        anthropic: { configured: true, status: "ready" },
+      },
+      cache: {
+        status: "healthy",
+      },
+    });
+  });
+
+  it("returns unhealthy when DB is down and AI providers are not configured", async () => {
+    delete process.env.AI_GATEWAY_API_KEY;
+    delete process.env.ANTHROPIC_API_KEY;
+    dbAllMock.mockRejectedValueOnce(new Error("db unavailable"));
+
+    const response = await GET();
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toMatchObject({
+      status: "unhealthy",
+      database: {
+        status: "unhealthy",
+        connected: false,
+      },
+      ai: {
+        status: "unhealthy",
+      },
+      cache: {
+        status: "healthy",
+      },
+    });
+  });
+});

--- a/src/app/api/search/route.test.ts
+++ b/src/app/api/search/route.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { POST } from "./route";
+import { checkPublicRateLimit } from "@/lib/rate-limit";
+import { getTrustedClientIp } from "@/lib/request-ip";
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    all: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/ai", () => ({
+  getEmbedding: vi.fn(),
+  embeddingToVectorString: vi.fn(),
+  expandQueryWithAI: vi.fn(),
+}));
+
+vi.mock("@/lib/synonyms", () => ({
+  expandQueryWithSynonyms: vi.fn((query: string) => query),
+  hasSynonyms: vi.fn(() => false),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    log: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  checkPublicRateLimit: vi.fn(),
+  getRateLimitHeaders: vi.fn().mockReturnValue({
+    "X-RateLimit-Limit": "60",
+    "X-RateLimit-Remaining": "0",
+    "X-RateLimit-Reset": "123",
+  }),
+}));
+
+vi.mock("@/lib/request-ip", () => ({
+  getTrustedClientIp: vi.fn(),
+}));
+
+describe("POST /api/search validation and protection", () => {
+  const checkPublicRateLimitMock = vi.mocked(checkPublicRateLimit);
+  const getTrustedClientIpMock = vi.mocked(getTrustedClientIp);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    getTrustedClientIpMock.mockReturnValue("203.0.113.9");
+    checkPublicRateLimitMock.mockResolvedValue({
+      success: true,
+      limit: 60,
+      remaining: 59,
+      reset: 123,
+    });
+  });
+
+  it("returns 429 when rate limit is exceeded", async () => {
+    checkPublicRateLimitMock.mockResolvedValue({
+      success: false,
+      limit: 60,
+      remaining: 0,
+      reset: 123,
+    });
+
+    const response = await POST(
+      new Request("https://example.com/api/search", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ query: "arrow" }),
+      }) as never
+    );
+
+    expect(response.status).toBe(429);
+    await expect(response.json()).resolves.toEqual({
+      error: "Rate limit exceeded. Please slow down.",
+    });
+  });
+
+  it("returns 400 when JSON body is invalid", async () => {
+    const response = await POST(
+      new Request("https://example.com/api/search", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{not-json",
+      }) as never
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Invalid JSON body",
+    });
+  });
+
+  it("returns 400 when query is missing", async () => {
+    const response = await POST(
+      new Request("https://example.com/api/search", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      }) as never
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Query is required",
+    });
+  });
+
+  it("returns 400 when sourceId has an invalid type", async () => {
+    const response = await POST(
+      new Request("https://example.com/api/search", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ query: "arrow", sourceId: 123 }),
+      }) as never
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "sourceId must be a string",
+    });
+  });
+
+  it("returns 400 when useAI has an invalid type", async () => {
+    const response = await POST(
+      new Request("https://example.com/api/search", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ query: "arrow", useAI: "yes" }),
+      }) as never
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "useAI must be a boolean",
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,6 +17,12 @@ export default defineConfig({
       provider: "v8",
       reporter: ["text-summary", "json-summary", "lcov"],
       reportsDirectory: "./coverage",
+      thresholds: {
+        lines: 12,
+        statements: 12,
+        functions: 8,
+        branches: 9,
+      },
       include: ["src/**/*.{ts,tsx}"],
       exclude: [
         "src/**/*.test.{ts,tsx}",


### PR DESCRIPTION
## Summary
- add route-level tests for `/api/health` and `/api/search` critical behavior paths
- enforce global coverage thresholds in Vitest (`lines/statements/functions/branches`)
- keep thresholds practical to current baseline while ensuring CI fails on regressions

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test 'src/app/api/health/route.test.ts' 'src/app/api/search/route.test.ts'
- pnpm test:coverage
  - Lines: 13.74%
  - Statements: 13.20%
  - Branches: 11.16%
  - Functions: 8.49%

Closes #78

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only additions plus CI coverage gating; no runtime code paths are changed, with the main risk being increased CI failure rates if coverage drops.
> 
> **Overview**
> Adds new Vitest coverage for critical API routes, including `/api/health` (healthy vs unhealthy responses based on DB, cache stats, and AI env config) and `/api/search` (rate-limit and request validation error cases).
> 
> Enforces a CI baseline by introducing global Vitest coverage `thresholds` (lines/statements/functions/branches) so coverage regressions fail the build.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 60ca10a4260c50caaaab8dd3702377063f962ae0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->