### PR TITLE
Fix #79: align health AI readiness with supported key configurations

### DIFF
--- a/src/app/api/health/route.test.ts
+++ b/src/app/api/health/route.test.ts
@@ -17,10 +17,14 @@ describe("GET /api/health", () => {
   const dbAllMock = vi.mocked(db.all);
   const getCacheStatsMock = vi.mocked(getCacheStats);
   const originalAiGatewayKey = process.env.AI_GATEWAY_API_KEY;
+  const originalOpenAiKey = process.env.OPENAI_API_KEY;
   const originalAnthropicKey = process.env.ANTHROPIC_API_KEY;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    dbAllMock
+      .mockResolvedValueOnce([{ count: 100 }])
+      .mockResolvedValueOnce([{ count: 80 }]);
 
     getCacheStatsMock.mockReturnValue({
       searchResults: { size: 10, maxSize: 100 },
@@ -36,6 +40,12 @@ describe("GET /api/health", () => {
       delete process.env.AI_GATEWAY_API_KEY;
     }
 
+    if (typeof originalOpenAiKey === "string") {
+      process.env.OPENAI_API_KEY = originalOpenAiKey;
+    } else {
+      delete process.env.OPENAI_API_KEY;
+    }
+
     if (typeof originalAnthropicKey === "string") {
       process.env.ANTHROPIC_API_KEY = originalAnthropicKey;
     } else {
@@ -43,43 +53,104 @@ describe("GET /api/health", () => {
     }
   });
 
-  it("returns healthy when DB, cache, and AI config checks pass", async () => {
-    process.env.AI_GATEWAY_API_KEY = "gateway-key";
-    process.env.ANTHROPIC_API_KEY = "anthropic-key";
+  it.each([
+    {
+      name: "AI Gateway + Anthropic",
+      gatewayKey: "gateway-key",
+      openAiKey: undefined,
+      anthropicKey: "anthropic-key",
+      expectedAiStatus: "healthy",
+      expectedHttpStatus: 200,
+      expectedOverallStatus: "healthy",
+      expectedOpenAiConfigured: true,
+      expectedAnthropicConfigured: true,
+    },
+    {
+      name: "OpenAI + Anthropic",
+      gatewayKey: undefined,
+      openAiKey: "openai-key",
+      anthropicKey: "anthropic-key",
+      expectedAiStatus: "healthy",
+      expectedHttpStatus: 200,
+      expectedOverallStatus: "healthy",
+      expectedOpenAiConfigured: true,
+      expectedAnthropicConfigured: true,
+    },
+    {
+      name: "OpenAI only",
+      gatewayKey: undefined,
+      openAiKey: "openai-key",
+      anthropicKey: undefined,
+      expectedAiStatus: "degraded",
+      expectedHttpStatus: 200,
+      expectedOverallStatus: "healthy",
+      expectedOpenAiConfigured: true,
+      expectedAnthropicConfigured: false,
+    },
+    {
+      name: "Anthropic only",
+      gatewayKey: undefined,
+      openAiKey: undefined,
+      anthropicKey: "anthropic-key",
+      expectedAiStatus: "degraded",
+      expectedHttpStatus: 200,
+      expectedOverallStatus: "healthy",
+      expectedOpenAiConfigured: false,
+      expectedAnthropicConfigured: true,
+    },
+    {
+      name: "No provider keys",
+      gatewayKey: undefined,
+      openAiKey: undefined,
+      anthropicKey: undefined,
+      expectedAiStatus: "unhealthy",
+      expectedHttpStatus: 503,
+      expectedOverallStatus: "unhealthy",
+      expectedOpenAiConfigured: false,
+      expectedAnthropicConfigured: false,
+    },
+  ])("reports AI readiness matrix correctly for $name", async (scenario) => {
+    if (scenario.gatewayKey) {
+      process.env.AI_GATEWAY_API_KEY = scenario.gatewayKey;
+    } else {
+      delete process.env.AI_GATEWAY_API_KEY;
+    }
 
-    dbAllMock
-      .mockResolvedValueOnce([{ count: 100 }])
-      .mockResolvedValueOnce([{ count: 80 }]);
+    if (scenario.openAiKey) {
+      process.env.OPENAI_API_KEY = scenario.openAiKey;
+    } else {
+      delete process.env.OPENAI_API_KEY;
+    }
+
+    if (scenario.anthropicKey) {
+      process.env.ANTHROPIC_API_KEY = scenario.anthropicKey;
+    } else {
+      delete process.env.ANTHROPIC_API_KEY;
+    }
 
     const response = await GET();
+    const payload = await response.json();
 
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toMatchObject({
-      status: "healthy",
-      database: {
-        status: "healthy",
-        connected: true,
-        icons: {
-          total: 100,
-          withEmbeddings: 80,
-          percentage: 80,
-        },
-      },
+    expect(response.status).toBe(scenario.expectedHttpStatus);
+    expect(payload).toMatchObject({
+      status: scenario.expectedOverallStatus,
       ai: {
-        status: "healthy",
-        openai: { configured: true, status: "ready" },
-        anthropic: { configured: true, status: "ready" },
-      },
-      cache: {
-        status: "healthy",
+        status: scenario.expectedAiStatus,
+        openai: {
+          configured: scenario.expectedOpenAiConfigured,
+        },
+        anthropic: {
+          configured: scenario.expectedAnthropicConfigured,
+        },
       },
     });
   });
 
-  it("returns unhealthy when DB is down and AI providers are not configured", async () => {
-    delete process.env.AI_GATEWAY_API_KEY;
-    delete process.env.ANTHROPIC_API_KEY;
-    dbAllMock.mockRejectedValueOnce(new Error("db unavailable"));
+  it("returns unhealthy when DB is down even if AI providers are configured", async () => {
+    process.env.OPENAI_API_KEY = "openai-key";
+    process.env.ANTHROPIC_API_KEY = "anthropic-key";
+    dbAllMock.mockReset();
+    dbAllMock.mockRejectedValue(new Error("db unavailable"));
 
     const response = await GET();
 
@@ -91,7 +162,7 @@ describe("GET /api/health", () => {
         connected: false,
       },
       ai: {
-        status: "unhealthy",
+        status: "healthy",
       },
       cache: {
         status: "healthy",

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -65,7 +65,7 @@ export async function GET() {
 
   // Check AI API configuration
   try {
-    const hasOpenAI = !!process.env.AI_GATEWAY_API_KEY;
+    const hasOpenAI = !!(process.env.AI_GATEWAY_API_KEY || process.env.OPENAI_API_KEY);
     const hasAnthropic = !!process.env.ANTHROPIC_API_KEY;
 
     checks.ai = {


### PR DESCRIPTION
## Summary
- update `/api/health` AI readiness logic to treat either `OPENAI_API_KEY` or `AI_GATEWAY_API_KEY` as valid OpenAI embedding configuration
- keep Anthropic readiness checks unchanged
- expand health endpoint tests with provider key matrix coverage to match runtime behavior

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test 'src/app/api/health/route.test.ts'
- pnpm test:coverage

Closes #79

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to health endpoint config detection plus broader test coverage; minimal risk outside of health-status reporting behavior.
> 
> **Overview**
> Updates `/api/health` AI configuration checking to treat either `AI_GATEWAY_API_KEY` *or* `OPENAI_API_KEY` as valid OpenAI readiness, aligning runtime health status with supported key setups.
> 
> Expands `route.test.ts` into a provider-key matrix (gateway/OpenAI/Anthropic/none) and adjusts expectations so DB failures still return overall unhealthy (503) even when AI is configured.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6be86f45de5b6e99cefc40666b5f104dce53a4dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->