### PR TITLE
Fix #80: add AI agent company logos starter pack

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -126,7 +126,7 @@ Retrieve multiple icons at once (max 50).
 Get a curated starter pack of icons for common use cases.
 
 **Parameters:**
-- `packId` (required): Starter pack ID (e.g., "dashboard", "ecommerce", "social", "brand-ai")
+- `packId` (required): Starter pack ID (e.g., "dashboard", "ecommerce", "social", "brand-ai-agents")
 - `format` (optional): Output format - default: react
 - `size` (optional): Icon size - default: 24
 - `strokeWidth` (optional): Stroke width - default: 2

--- a/src/app/api/mcp/handlers/resources.ts
+++ b/src/app/api/mcp/handlers/resources.ts
@@ -158,7 +158,7 @@ Get multiple icons at once (up to 50). Returns a single bundled file.
 ### 4. get_starter_pack
 Get a curated set of icons for common use cases.
 
-**Popular packs:** shadcn-ui, dashboard, ecommerce, navigation, developer, brand-ai
+**Popular packs:** shadcn-ui, dashboard, ecommerce, navigation, developer, brand-ai-agents, brand-ai
 
 **Example:**
 \`\`\`json

--- a/src/app/api/mcp/handlers/starter-packs.ts
+++ b/src/app/api/mcp/handlers/starter-packs.ts
@@ -32,7 +32,7 @@ export function registerStarterPackTools(server: McpServer) {
       title: "Get Starter Pack",
       description: `Get a curated starter pack of icons for common use cases.
 
-Popular packs: shadcn-ui, dashboard, ecommerce, navigation, developer, brand-ai
+Popular packs: shadcn-ui, dashboard, ecommerce, navigation, developer, brand-ai-agents, brand-ai
 
 Args:
   - packId (string): Starter pack ID

--- a/src/app/docs/mcp/page.tsx
+++ b/src/app/docs/mcp/page.tsx
@@ -617,7 +617,7 @@ export default function MCPDocsPage() {
               <div className="text-xs font-mono text-muted-foreground">
                 <div>Parameters:</div>
                 <div className="ml-4 mt-1">
-                  <div>• packId (required) - Pack ID (dashboard, ecommerce, social, brand-ai)</div>
+                  <div>• packId (required) - Pack ID (dashboard, ecommerce, social, brand-ai-agents)</div>
                   <div>• format (optional) - Output format for all icons</div>
                   <div>• size (optional) - Size for all icons</div>
                   <div>• strokeWidth (optional) - Stroke width for all icons</div>

--- a/src/lib/starter-packs.test.ts
+++ b/src/lib/starter-packs.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { STARTER_PACKS } from "./starter-packs";
+
+describe("STARTER_PACKS", () => {
+  it("has unique pack IDs", () => {
+    const ids = STARTER_PACKS.map((pack) => pack.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("includes an AI agent/company logo starter pack with documented substitutions", () => {
+    const pack = STARTER_PACKS.find((entry) => entry.id === "brand-ai-agents");
+    expect(pack).toBeDefined();
+
+    expect(pack?.iconNames).toEqual(
+      expect.arrayContaining([
+        "openai",
+        "anthropic",
+        "googlegemini",
+        "meta",
+        "xai",
+        "perplexity",
+        "mistralai",
+        "cohere",
+        "huggingface",
+        "stabilityai",
+      ])
+    );
+
+    expect(pack?.description.toLowerCase()).toContain("substitutions");
+  });
+});

--- a/src/lib/starter-packs.ts
+++ b/src/lib/starter-packs.ts
@@ -1035,6 +1035,29 @@ export const STARTER_PACKS: StarterPack[] = [
   // Brand Icon Packs (Simple Icons)
   // ─────────────────────────────────────────────────────────────────────────────
   {
+    id: "brand-ai-agents",
+    name: "AI Agent Company Logos",
+    description:
+      "Core AI company logos for agentic prototypes. Includes practical substitutions (Google AI → Gemini mark, Mistral → mistralai slug).",
+    color: "violet",
+    iconNames: [
+      "openai",
+      "anthropic",
+      "googlegemini",
+      "meta",
+      "xai",
+      "perplexity",
+      "mistralai",
+      "cohere",
+      "huggingface",
+      "stabilityai",
+      // Documented fallback marks when specific logos are unavailable.
+      "claude",
+      "grok",
+      "stablediffusion",
+    ],
+  },
+  {
     id: "brand-ai",
     name: "AI & LLM Brands",
     description: "Logos for AI companies and LLM providers",
@@ -1247,4 +1270,3 @@ export const STARTER_PACKS: StarterPack[] = [
     ],
   },
 ];
-


### PR DESCRIPTION
## Summary
- add new `brand-ai-agents` starter pack focused on AI company/agent logos
- include documented substitution logos in pack contents for graceful fallback behavior
- update MCP descriptions/docs examples to reference the new starter pack ID
- add starter-pack tests to ensure the new pack is present and includes requested logos

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test src/lib/starter-packs.test.ts

Closes #80

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly additive data/docs plus a small test suite; minimal runtime risk beyond ensuring referenced icon slugs exist in the underlying icon set.
> 
> **Overview**
> Adds a new starter pack, `brand-ai-agents`, providing a curated set of AI agent/company logos (with documented fallback substitutions) to the `STARTER_PACKS` list.
> 
> Updates MCP tool/docs copy (README, `/docs/mcp`, and MCP `instructions`/tool description) to advertise the new `packId`, and adds a Vitest suite to ensure starter pack IDs remain unique and that `brand-ai-agents` contains the expected logos and mentions substitutions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ccdc379b7ef941892d8b522b0a3b874b212104f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->