### PR TITLE
Fix #73: enforce schema/RPC alignment migration contracts

### DIFF
--- a/src/__tests__/schema-rpc-alignment.test.ts
+++ b/src/__tests__/schema-rpc-alignment.test.ts
@@ -1,0 +1,36 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const migrationsDir = join(process.cwd(), "supabase", "migrations");
+const allMigrationSql = readdirSync(migrationsDir)
+  .filter((file) => file.endsWith(".sql"))
+  .sort()
+  .map((file) => readFileSync(join(migrationsDir, file), "utf8"))
+  .join("\n\n");
+
+describe("schema/RPC migration alignment", () => {
+  it("includes teams.logo_url used by team logo routes", () => {
+    expect(allMigrationSql).toMatch(
+      /alter\s+table\s+public\.teams[\s\S]*add\s+column\s+if\s+not\s+exists\s+logo_url\s+text/i
+    );
+  });
+
+  it("includes create_bundle_atomic args used by bundle create flows", () => {
+    expect(allMigrationSql).toMatch(
+      /create\s+or\s+replace\s+function\s+public\.create_bundle_atomic\([\s\S]*p_normalize_viewbox\s+boolean[\s\S]*p_target_viewbox\s+text/i
+    );
+  });
+
+  it("includes list_api_sessions RPC used by token listing API", () => {
+    expect(allMigrationSql).toMatch(
+      /create\s+or\s+replace\s+function\s+public\.list_api_sessions\s*\(\s*p_user_id\s+uuid\s*\)/i
+    );
+  });
+
+  it("includes create_api_token_direct RPC used by token creation API", () => {
+    expect(allMigrationSql).toMatch(
+      /create\s+or\s+replace\s+function\s+public\.create_api_token_direct\s*\(\s*p_user_id\s+uuid[\s\S]*p_name\s+text[\s\S]*p_scope\s+text[\s\S]*\)\s*returns\s+jsonb/i
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a regression test that scans committed Supabase migrations for runtime-required schema/RPC contracts
- assert coverage for `teams.logo_url`, extended `create_bundle_atomic` args, `list_api_sessions`, and `create_api_token_direct`
- prevent drift regressions where runtime code references columns/RPCs not present in migrations

## Validation
- pnpm test src/__tests__/schema-rpc-alignment.test.ts
- pnpm typecheck
- pnpm lint

Fixes #73

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that adds assertions over migration SQL; no runtime logic or data handling paths are modified.
> 
> **Overview**
> Adds a new Vitest regression test (`schema-rpc-alignment.test.ts`) that scans all committed Supabase migration SQL and asserts required schema/RPC contracts exist.
> 
> The test locks in expectations for `teams.logo_url`, the `create_bundle_atomic` signature (including viewBox params), and the `list_api_sessions` / `create_api_token_direct` RPCs used by token APIs, helping prevent runtime code from drifting ahead of migrations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 30c55b201004bae480333ab259b2cf17159a82ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->