### PR TITLE
Fix #72: harden SVG sanitization and add route regressions

### DIFF
--- a/src/__tests__/svg-sanitizer.test.ts
+++ b/src/__tests__/svg-sanitizer.test.ts
@@ -23,6 +23,18 @@ describe("sanitizeSvgContent", () => {
     expect(sanitized).toContain("<a>");
     expect(sanitized).toContain("<use");
   });
+
+  it("removes style attributes and scriptable data URLs", () => {
+    const input = `<path d="M3 3" style="fill:url(javascript:alert(1));stroke:red" /><image href="data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=" /><use xlink:href="data:application/javascript,alert(1)" />`;
+    const sanitized = sanitizeSvgContent(input);
+
+    expect(sanitized).not.toContain("style=");
+    expect(sanitized).not.toContain("javascript:");
+    expect(sanitized).not.toContain("data:");
+    expect(sanitized).toContain(`<path d="M3 3" />`);
+    expect(sanitized).toContain("<image");
+    expect(sanitized).toContain("<use");
+  });
 });
 
 describe("sanitizeBundleIcons", () => {

--- a/src/app/api/bundles/[id]/route.test.ts
+++ b/src/app/api/bundles/[id]/route.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { DELETE } from "./route";
+import { DELETE, PATCH } from "./route";
 import { createClient } from "@/lib/supabase/server";
 
 vi.mock("@/lib/supabase/server", () => ({
@@ -11,6 +11,7 @@ type MockSupabaseClient = {
     getUser: ReturnType<typeof vi.fn>;
   };
   from: ReturnType<typeof vi.fn>;
+  rpc?: ReturnType<typeof vi.fn>;
 };
 
 function createDeleteChain(result: { data: Array<{ id: string }>; error: { message: string } | null }) {
@@ -26,6 +27,27 @@ function createDeleteChain(result: { data: Array<{ id: string }>; error: { messa
     eqId,
     eqUser,
     select,
+  };
+}
+
+function createPatchChain(result: {
+  data: Record<string, unknown> | null;
+  error: { message: string; code?: string } | null;
+}) {
+  const single = vi.fn().mockResolvedValue(result);
+  const select = vi.fn().mockReturnValue({ single });
+  const eqUser = vi.fn().mockReturnValue({ select });
+  const eqId = vi.fn().mockReturnValue({ eq: eqUser });
+  const update = vi.fn().mockReturnValue({ eq: eqId });
+  const from = vi.fn().mockReturnValue({ update });
+
+  return {
+    from,
+    update,
+    eqId,
+    eqUser,
+    select,
+    single,
   };
 }
 
@@ -108,5 +130,86 @@ describe("DELETE /api/bundles/[id]", () => {
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ success: true });
+  });
+});
+
+describe("PATCH /api/bundles/[id]", () => {
+  const createClientMock = vi.mocked(createClient);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 400 when icons payload is invalid", async () => {
+    const chain = createPatchChain({ data: { id: "bundle-1" }, error: null });
+    const supabase: MockSupabaseClient = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: "user-1" } },
+          error: null,
+        }),
+      },
+      from: chain.from,
+    };
+
+    createClientMock.mockResolvedValue(supabase as unknown as Awaited<ReturnType<typeof createClient>>);
+
+    const response = await PATCH(
+      new Request("https://example.com/api/bundles/bundle-1", {
+        method: "PATCH",
+        body: JSON.stringify({ icons: ["bad"] }),
+      }),
+      { params: Promise.resolve({ id: "bundle-1" }) }
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "icons must be an array of objects",
+    });
+    expect(chain.from).not.toHaveBeenCalled();
+  });
+
+  it("sanitizes icon payloads before updating bundles", async () => {
+    const chain = createPatchChain({ data: { id: "bundle-1" }, error: null });
+    const supabase: MockSupabaseClient = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: "user-1" } },
+          error: null,
+        }),
+      },
+      from: chain.from,
+    };
+
+    createClientMock.mockResolvedValue(supabase as unknown as Awaited<ReturnType<typeof createClient>>);
+
+    const response = await PATCH(
+      new Request("https://example.com/api/bundles/bundle-1", {
+        method: "PATCH",
+        body: JSON.stringify({
+          icons: [
+            {
+              id: "tabler:home",
+              content:
+                `<foreignObject><iframe src="javascript:1"></iframe></foreignObject>` +
+                `<path d="M2 2" onclick="evil()" style="fill:url(javascript:1)" />`,
+            },
+          ],
+        }),
+      }),
+      { params: Promise.resolve({ id: "bundle-1" }) }
+    );
+
+    expect(response.status).toBe(200);
+    const updates = chain.update.mock.calls[0]?.[0] as {
+      icons: Array<{ content: string }>;
+    };
+    const sanitizedContent = updates.icons[0]?.content;
+
+    expect(sanitizedContent).toContain(`<path d="M2 2"`);
+    expect(sanitizedContent).not.toContain("<foreignObject");
+    expect(sanitizedContent).not.toContain("onclick=");
+    expect(sanitizedContent).not.toContain("style=");
+    expect(sanitizedContent).not.toContain("javascript:");
   });
 });

--- a/src/app/api/bundles/route.test.ts
+++ b/src/app/api/bundles/route.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { POST } from "./route";
+import { createClient } from "@/lib/supabase/server";
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(),
+}));
+
+type MockSupabaseClient = {
+  auth: {
+    getUser: ReturnType<typeof vi.fn>;
+  };
+  rpc: ReturnType<typeof vi.fn>;
+};
+
+describe("POST /api/bundles", () => {
+  const createClientMock = vi.mocked(createClient);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 when user is not authenticated", async () => {
+    const supabase: MockSupabaseClient = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: null },
+          error: { message: "unauthorized" },
+        }),
+      },
+      rpc: vi.fn(),
+    };
+
+    createClientMock.mockResolvedValue(supabase as unknown as Awaited<ReturnType<typeof createClient>>);
+
+    const response = await POST(
+      new Request("https://example.com/api/bundles", {
+        method: "POST",
+        body: JSON.stringify({ name: "test", icons: [] }),
+      })
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: "Unauthorized" });
+    expect(supabase.rpc).not.toHaveBeenCalled();
+  });
+
+  it("sanitizes icon SVG payloads before create_bundle_atomic RPC", async () => {
+    const rpc = vi.fn().mockResolvedValue({
+      data: [{ success: true, bundle: { id: "bundle-1" } }],
+      error: null,
+    });
+    const supabase: MockSupabaseClient = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: "user-1" } },
+          error: null,
+        }),
+      },
+      rpc,
+    };
+
+    createClientMock.mockResolvedValue(supabase as unknown as Awaited<ReturnType<typeof createClient>>);
+
+    const response = await POST(
+      new Request("https://example.com/api/bundles", {
+        method: "POST",
+        body: JSON.stringify({
+          name: "unsafe bundle",
+          icons: [
+            {
+              id: "lucide:alert",
+              svg: `<script>alert(1)</script><path d="M1 1" onload="evil()" style="fill:url(javascript:1)" />`,
+            },
+          ],
+        }),
+      })
+    );
+
+    expect(response.status).toBe(201);
+    const rpcArgs = rpc.mock.calls[0]?.[1] as { p_icons: Array<{ svg: string }> };
+    const sanitizedSvg = rpcArgs.p_icons[0]?.svg;
+
+    expect(sanitizedSvg).toContain(`<path d="M1 1"`);
+    expect(sanitizedSvg).not.toContain("<script");
+    expect(sanitizedSvg).not.toContain("onload=");
+    expect(sanitizedSvg).not.toContain("style=");
+    expect(sanitizedSvg).not.toContain("javascript:");
+  });
+
+  it("returns 400 for invalid icon payload arrays", async () => {
+    const supabase: MockSupabaseClient = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: "user-1" } },
+          error: null,
+        }),
+      },
+      rpc: vi.fn(),
+    };
+
+    createClientMock.mockResolvedValue(supabase as unknown as Awaited<ReturnType<typeof createClient>>);
+
+    const response = await POST(
+      new Request("https://example.com/api/bundles", {
+        method: "POST",
+        body: JSON.stringify({
+          name: "invalid",
+          icons: ["bad"],
+        }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "icons must be an array of objects",
+    });
+    expect(supabase.rpc).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/svg-sanitizer.ts
+++ b/src/lib/svg-sanitizer.ts
@@ -39,6 +39,11 @@ function stripEventHandlers(input: string): string {
   return input.replace(/\s+on[a-zA-Z-]+\s*=\s*(".*?"|'.*?'|[^\s>]+)/gi, "");
 }
 
+function stripStyleAttributes(input: string): string {
+  // Remove inline style attributes to avoid CSS-based scriptable payloads.
+  return input.replace(/\s+style\s*=\s*(".*?"|'.*?'|[^\s>]+)/gi, "");
+}
+
 function stripUnsafeUrls(input: string): string {
   // Drop href/src attributes using scriptable protocols.
   return input.replace(
@@ -48,8 +53,8 @@ function stripUnsafeUrls(input: string): string {
       const isUnsafe =
         rawValue.startsWith("javascript:") ||
         rawValue.startsWith("vbscript:") ||
-        rawValue.startsWith("data:text/html") ||
-        rawValue.startsWith("data:application/javascript");
+        rawValue.startsWith("data:") ||
+        rawValue.startsWith("file:");
 
       return isUnsafe ? "" : fullMatch;
     }
@@ -60,6 +65,7 @@ export function sanitizeSvgContent(input: string): string {
   let output = input.replace(/\0/g, "");
   output = stripBlockedTags(output);
   output = stripEventHandlers(output);
+  output = stripStyleAttributes(output);
   output = stripUnsafeUrls(output);
   return output.trim();
 }


### PR DESCRIPTION
## Summary
- harden SVG sanitization by stripping inline `style` attributes from user-supplied icon payloads
- treat all `data:` URL payloads in `href`/`xlink:href`/`src` as unsafe and remove them
- add route-level regression tests proving sanitize-before-persist behavior in both bundle create and update APIs
- expand sanitizer unit tests for style attribute and `data:` URL payload variants

## Validation
- pnpm test src/__tests__/svg-sanitizer.test.ts src/app/api/bundles/route.test.ts 'src/app/api/bundles/[id]/route.test.ts'
- pnpm typecheck
- pnpm lint

Fixes #72

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches user-supplied SVG sanitization and bundle persistence paths; while changes are straightforward, incorrect sanitization could enable XSS or break legitimate icon rendering.
> 
> **Overview**
> **Hardens SVG sanitization** by stripping inline `style` attributes and treating *all* `data:` (plus `file:`) URLs in `href`/`xlink:href`/`src` as unsafe and removing them.
> 
> Adds regression coverage to ensure bundle create/update APIs sanitize icon payloads before persisting (including 400s for invalid `icons` arrays), and expands sanitizer unit tests for style- and `data:`-based payload variants.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 91b78f4d4397ab35e213397f338f392af382c66d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->