### PR TITLE
fix(hooks): comply with eslint-plugin-react-hooks 7.1 strict rules

### DIFF
--- a/src/components/bundles/bundle-editor.tsx
+++ b/src/components/bundles/bundle-editor.tsx
@@ -50,12 +50,20 @@ export function BundleEditor({ bundle, onUpdate }: BundleEditorProps) {
     return () => clearTimeout(timer);
   }, [searchQuery]);
 
-  // Trigger search when debounced query changes
-  useEffect(() => {
+  // Clear results synchronously when the user empties the search box. The
+  // render-time "compare-prev-value" pattern avoids the setState-in-effect
+  // anti-pattern while keeping the actual fetch logic inside its useEffect.
+  const [prevDebouncedQuery, setPrevDebouncedQuery] = useState(debouncedQuery);
+  if (prevDebouncedQuery !== debouncedQuery) {
+    setPrevDebouncedQuery(debouncedQuery);
     if (!debouncedQuery.trim()) {
       setSearchResults([]);
-      return;
     }
+  }
+
+  // Trigger search when debounced query changes
+  useEffect(() => {
+    if (!debouncedQuery.trim()) return;
 
     // Cancel any in-flight request to prevent stale results
     if (abortControllerRef.current) {

--- a/src/components/bundles/use-bundle-browser.ts
+++ b/src/components/bundles/use-bundle-browser.ts
@@ -128,10 +128,15 @@ export function useBundleBrowser({
     return () => controller.abort();
   }, [debouncedSearch, selectedSource, selectedCategory, page]);
 
-  // Reset page when filters change
-  useEffect(() => {
-    setPage(0);
-  }, [debouncedSearch, selectedSource, selectedCategory]);
+  // Reset page when filters change. React-blessed "compare-prev-value" pattern
+  // avoids the setState-in-effect anti-pattern: React reruns the component
+  // before effects fire, so the fetch effect below already sees page === 0.
+  const filterKey = `${debouncedSearch}|${selectedSource}|${selectedCategory}`;
+  const [prevFilterKey, setPrevFilterKey] = useState(filterKey);
+  if (prevFilterKey !== filterKey) {
+    setPrevFilterKey(filterKey);
+    if (page !== 0) setPage(0);
+  }
 
   // Icon operations
   const handleAddIcon = useCallback((icon: IconData) => {

--- a/src/components/icons/use-icon-browser.ts
+++ b/src/components/icons/use-icon-browser.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import { logger } from "@/lib/logger";
 import { iconSearchCache } from "@/lib/search-cache";
 import { useEventListener } from "@/lib/use-event-listener";
@@ -31,6 +31,21 @@ function buildIconSearchParams(opts: {
   return params;
 }
 
+// SSR-safe viewport tracking via useSyncExternalStore — avoids the
+// setState-in-effect anti-pattern while still rendering `null` on the server
+// to match initial client hydration.
+function subscribeViewport(callback: () => void) {
+  if (typeof window === "undefined") return () => {};
+  window.addEventListener("resize", callback);
+  return () => window.removeEventListener("resize", callback);
+}
+function getViewportSnapshot(): number | null {
+  return typeof window === "undefined" ? null : window.innerWidth;
+}
+function getServerViewportSnapshot(): number | null {
+  return null;
+}
+
 export function useIconBrowser({ initialIcons, totalCount }: UseIconBrowserParams) {
   const [search, setSearch] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
@@ -53,7 +68,11 @@ export function useIconBrowser({ initialIcons, totalCount }: UseIconBrowserParam
   const { icon: iconSize, container: containerSize } = SIZE_PRESETS[sizePreset];
 
   // Estimate columns based on viewport width
-  const [viewportWidth, setViewportWidth] = useState<number | null>(null);
+  const viewportWidth = useSyncExternalStore(
+    subscribeViewport,
+    getViewportSnapshot,
+    getServerViewportSnapshot,
+  );
 
   const estimatedColumns = (() => {
     if (viewportWidth === null) return 10;
@@ -79,28 +98,23 @@ export function useIconBrowser({ initialIcons, totalCount }: UseIconBrowserParam
   // Hover state for library chip highlighting
   const [hoveredSource, setHoveredSource] = useState<string | null>(null);
 
-  const handleResize = useCallback(() => {
-    setViewportWidth(window.innerWidth);
-  }, []);
-
   const handleOpenCart = useCallback(() => {
     setIsCartOpen(true);
   }, []);
 
-  useEffect(() => {
-    setViewportWidth(window.innerWidth);
-  }, []);
-
-  useEventListener("resize", handleResize);
   useEventListener("openCart", handleOpenCart);
 
-  // Load settings from localStorage on mount
+  // Load settings from localStorage on mount. We intentionally read AFTER
+  // hydration (not via a lazy initializer) so SSR-rendered markup matches the
+  // initial client render — the alternative would cause hydration mismatches
+  // on cart badges/size/stroke UI rendered from initial state.
   useEffect(() => {
     try {
       const savedCart = localStorage.getItem("unicon-bundle");
       if (savedCart) {
         const parsed = JSON.parse(savedCart) as IconData[];
         if (Array.isArray(parsed) && parsed.length > 0) {
+          // eslint-disable-next-line react-hooks/set-state-in-effect -- post-hydration rehydration of persisted UI state; see comment above.
           setCartItems(parsed);
         }
       }
@@ -334,23 +348,29 @@ export function useIconBrowser({ initialIcons, totalCount }: UseIconBrowserParam
     [debouncedSearch, selectedSource, selectedCategory]
   );
 
-  // Use a ref for fetchIcons to avoid stale closures in effects
-  // without adding fetchIcons to their dependency arrays (which would cause double-fetching)
+  // Use a ref for fetchIcons to avoid stale closures in effects without adding
+  // fetchIcons to their dependency arrays. The ref is read inside other
+  // effects (after this one commits), so a single-effect sync is safe.
   const fetchIconsRef = useRef(fetchIcons);
-  fetchIconsRef.current = fetchIcons;
-
-  // Refetch when filters change - reset to page 0
   useEffect(() => {
-    setPage(0);
-    fetchIconsRef.current(0);
-  }, [debouncedSearch, selectedSource, selectedCategory]);
+    fetchIconsRef.current = fetchIcons;
+  });
 
-  // Fetch when page changes (but not when filters change, since that's handled above)
+  // Reset to page 0 when filters change, using the React-blessed
+  // "compare-prev-value" pattern so we don't setState inside an effect.
+  const filterKey = `${debouncedSearch}|${selectedSource}|${selectedCategory}`;
+  const [prevFilterKey, setPrevFilterKey] = useState(filterKey);
+  if (prevFilterKey !== filterKey) {
+    setPrevFilterKey(filterKey);
+    if (page !== 0) setPage(0);
+  }
+
+  // Fetch whenever filters or page change. The render-time setPage(0) above
+  // collapses a filter-change-at-page-N into a single fetch at page 0 (because
+  // React reruns this component before effects fire).
   useEffect(() => {
-    if (page > 0) {
-      fetchIconsRef.current(page);
-    }
-  }, [page]);
+    fetchIconsRef.current(page);
+  }, [debouncedSearch, selectedSource, selectedCategory, page]);
 
   // Abort any in-flight request on unmount so it can't update state afterwards.
   useEffect(() => () => abortRef.current?.abort(), []);


### PR DESCRIPTION
## Why

Dependabot PR #160 lifts `eslint-plugin-react-hooks` from 7.0.1 → 7.1.1 as part of the dev-dependencies group bump. The 7.1 release activates several React Compiler-grade rules at **error** level — `react-hooks/set-state-in-effect`, `react-hooks/refs`, etc. — which catch six real anti-patterns in our hooks. CI on #160 currently fails on these.

This PR restructures the offending code so #160 (and any future bump) goes through clean.

## What changes

| File | Violation → Fix |
|---|---|
| `use-icon-browser.ts` | viewport: mount-effect `setViewportWidth` → `useSyncExternalStore` (SSR-safe, no setState-in-effect). Drops `handleResize` callback. |
| `use-icon-browser.ts` | `fetchIconsRef.current = fetchIcons` during render → moved into a `useEffect` (rule forbids ref writes during render). Reads stay in effects, where the rule allows them. |
| `use-icon-browser.ts` | `setPage(0)` in filter-change effect → React-blessed compare-prev-value render-time pattern. **Side benefit:** collapses double-fetch on filter-change-at-page-N into a single fetch at page 0. |
| `use-bundle-browser.ts` | Same compare-prev-value pattern for the filter-reset effect. |
| `bundle-editor.tsx` | `setSearchResults([])` on empty-query in effect → compare-prev-value render-time. The async fetch stays inside its useEffect. |

## What stays

Cart / stroke / size preset rehydration in `use-icon-browser` still uses a `useEffect` with an inline `eslint-disable` and explanatory comment. Switching to a lazy initializer would cause hydration mismatches on cart-badge UI rendered from initial state; `useSyncExternalStore` for parsed-JSON localStorage data would either be reference-unstable or require a manual memo store. Post-hydration setState is the documented exception.

## Verification

Locally bumped `eslint-plugin-react-hooks` to `7.1.1` to mirror #160's lockfile:

```
pnpm lint        # 0 errors (35 complexity warnings, pre-existing)
pnpm typecheck   # clean
pnpm test        # 117 passed (incl. use-icon-browser request-sequencing tests)
pnpm build       # ok
```

Both pre-existing `use-icon-browser` hook tests still pass — the stale-response race fix from #149 is preserved.

## Follow-up

Once this merges, `@dependabot rebase` PR #160 — its CI will then run lint with the new plugin against the fixed code and go green. Auto-merge is already armed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/webrenew/codesmith/unicon/pr/162"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->