### PR TITLE
fix(sentry): filter non-actionable React hoistable head crash

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -7,6 +7,15 @@ Sentry.init({
   replaysSessionSampleRate: 0,
   replaysOnErrorSampleRate: 1.0,
   integrations: [Sentry.replayIntegration()],
+  ignoreErrors: [
+    // React 19 hoistable crash: external tools (translation extensions,
+    // in-app webviews, ad blockers) detach document.head, so React's
+    // mountHoistable hits `head.insertBefore` on a null head. Not an app bug
+    // and not fixable in app code — suppress the non-actionable noise.
+    /\.head\.insertBefore/,
+    "(reading 'insertBefore')",
+    "null is not an object (evaluating '(e=e.ownerDocument||e).head.insertBefore')",
+  ],
 });
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,6 +1,15 @@
 import * as Sentry from "@sentry/nextjs";
 import { registerOTel } from "@vercel/otel";
 
+// Mirror of the client-side filter (see instrumentation-client.ts). This is a
+// browser-only DOM crash and won't fire server-side, but keeping the configs
+// symmetric avoids surprises if these patterns ever surface in SSR.
+const ignoreErrors = [
+  /\.head\.insertBefore/,
+  "(reading 'insertBefore')",
+  "null is not an object (evaluating '(e=e.ownerDocument||e).head.insertBefore')",
+];
+
 export async function register() {
   if (process.env.NEXT_RUNTIME === "nodejs") {
     registerOTel({
@@ -12,6 +21,7 @@ export async function register() {
       dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
       environment: process.env.VERCEL_ENV || "development",
       tracesSampleRate: 0,
+      ignoreErrors,
     });
   }
 
@@ -20,6 +30,7 @@ export async function register() {
       dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
       environment: process.env.VERCEL_ENV || "development",
       tracesSampleRate: 0,
+      ignoreErrors,
     });
   }
 }


### PR DESCRIPTION
## Problem

Sentry is reporting an uncaught `TypeError`:

> `null is not an object (evaluating '(e=e.ownerDocument||e).head.insertBefore')`

(`mechanism: auto.browser.global_handlers.onerror`, `handled: false`)

This is the well-known **React 19 hoistable crash**. React's `mountHoistable` inserts metadata nodes (`<title>`/`<meta>`/`<link>`) into `document.head` during client navigation via `head.insertBefore(...)`. The crash means `document.head` was `null` at that moment.

## Root cause

`document.head` going null comes from **outside app code** — overwhelmingly browser translation extensions (Google/Microsoft/Yandex Translate), in-app webviews (Facebook/Instagram), and aggressive ad blockers that detach `<head>`. None of our in-tree elements are actually hoistable (no `<style precedence>`, no `<script async src>`), so we never trigger this path destructively ourselves.

It's not fixable in app code, and `global-error.tsx` already prevents a full app crash — this was just noise that also burns the error-replay quota (`replaysOnErrorSampleRate: 1.0`).

## Change

- Add `ignoreErrors` patterns to `instrumentation-client.ts` covering the WebKit and Chrome phrasings of the crash.
- Mirror the same filter into the server/edge `Sentry.init` in `instrumentation.ts` for config symmetry (won't fire server-side, but keeps configs in sync).

## Trade-off

The `"(reading 'insertBefore')"` substring is slightly broad — a *different* genuine null-`insertBefore` bug would also be filtered. Given the rarity of that vs. the extension noise, this is intentional; easy to tighten later if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/webrenew/codesmith/unicon/pr/163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782419236&installation_id=129242532&pr_number=163&repository=webrenew%2Funicon&return_to=https%3A%2F%2Fgithub.com%2Fwebrenew%2Funicon%2Fpull%2F163&signature=3ba46b7170e0a8d5c30ee01c15c09917ba8f5e9ed401ea6f5d5a16a8e97d75e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->