### PR TITLE
fix: enable saved bundle exports

### DIFF
--- a/src/components/bundles/bundle-browser.test.tsx
+++ b/src/components/bundles/bundle-browser.test.tsx
@@ -1,0 +1,83 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { BundleBrowser } from "./bundle-browser";
+import type { Bundle } from "@/types/database";
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const bundle: Bundle = {
+  id: "bundle-1",
+  user_id: "user-1",
+  name: "Navigation Icons",
+  description: null,
+  is_public: false,
+  share_slug: null,
+  stroke_preset: null,
+  normalize_strokes: false,
+  target_stroke_width: null,
+  normalize_viewbox: false,
+  target_viewbox: null,
+  icons: [
+    {
+      id: "lucide:arrow-right",
+      name: "Arrow Right",
+      normalizedName: "arrow-right",
+      sourceId: "lucide",
+      svg: '<path d="M5 12h14" /><path d="m12 5 7 7-7 7" />',
+      viewBox: "0 0 24 24",
+      strokeWidth: "2",
+      defaultFill: false,
+      defaultStroke: true,
+    },
+  ],
+  icon_count: 1,
+  created_at: "2026-01-01T00:00:00.000Z",
+  updated_at: "2026-01-01T00:00:00.000Z",
+};
+
+describe("BundleBrowser export", () => {
+  let createObjectURL: ReturnType<typeof vi.fn>;
+  let revokeObjectURL: ReturnType<typeof vi.fn>;
+  let clickAnchor: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    createObjectURL = vi.fn(() => "blob:bundle-export");
+    revokeObjectURL = vi.fn();
+    vi.stubGlobal("URL", {
+      ...URL,
+      createObjectURL,
+      revokeObjectURL,
+    });
+    clickAnchor = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    clickAnchor.mockRestore();
+    vi.unstubAllGlobals();
+  });
+
+  it("downloads the saved bundle export from the header export menu", () => {
+    render(
+      <BundleBrowser
+        bundle={bundle}
+        categories={[]}
+        initialIcons={[]}
+        totalIconCount={0}
+        countBySource={{}}
+        onUpdate={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /export/i }));
+    fireEvent.click(screen.getByRole("button", { name: /download/i }));
+
+    expect(createObjectURL).toHaveBeenCalledWith(expect.any(Blob));
+    expect(clickAnchor).toHaveBeenCalled();
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:bundle-export");
+  });
+});

--- a/src/components/bundles/bundle-browser.tsx
+++ b/src/components/bundles/bundle-browser.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
 import { ArrowLeftIcon } from "@/components/icons/ui/arrow-left";
 import { PackageIcon } from "@/components/icons/ui/package";
@@ -15,6 +16,9 @@ import { ChevronsUpDownIcon } from "@/components/icons/ui/chevrons-up-down";
 import { DownloadIcon } from "@/components/icons/ui/download";
 import { ChevronLeftIcon } from "@/components/icons/ui/chevron-left";
 import { ChevronRightIcon } from "@/components/icons/ui/chevron-right";
+import { CopyIcon } from "@/components/icons/ui/copy";
+import { FileCodeIcon } from "@/components/icons/ui/file-code";
+import { FileJsonIcon } from "@/components/icons/ui/file-json";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import {
   Command,
@@ -25,6 +29,8 @@ import {
   CommandList,
 } from "@/components/ui/command";
 import { StyledIcon, SIZE_PRESETS, STROKE_PRESETS, type SizePreset, type StrokePreset } from "@/components/icons/styled-icon";
+import { generateBundleExport, type BundleExportFormat } from "@/lib/bundle-export";
+import { toast } from "sonner";
 import type { Bundle } from "@/types/database";
 import type { IconData, IconLibrary } from "@/types/icon";
 import { useBundleBrowser } from "./use-bundle-browser";
@@ -80,6 +86,8 @@ function toTitleCase(value: string): string {
 }
 
 export function BundleBrowser({ bundle, categories, initialIcons, totalIconCount, countBySource, onUpdate }: BundleBrowserProps) {
+  const [exportFormat, setExportFormat] = useState<BundleExportFormat>("react");
+  const [copiedExport, setCopiedExport] = useState(false);
   const {
     bundleIcons,
     normalizeStrokes,
@@ -128,6 +136,46 @@ export function BundleBrowser({ bundle, categories, initialIcons, totalIconCount
     handleSave,
     renderBundleIcon,
   } = useBundleBrowser({ bundle, initialIcons, totalIconCount, onUpdate });
+
+  const createExport = () => generateBundleExport(bundle.name, {
+    icons: bundleIcons,
+    format: exportFormat,
+    normalizeStrokes,
+    targetStrokeWidth,
+    normalizeViewbox,
+  });
+
+  const handleCopyExport = async () => {
+    const exportResult = createExport();
+    if (exportResult.exportedIconCount === 0) {
+      toast.error("No exportable icons in this bundle");
+      return;
+    }
+
+    await navigator.clipboard.writeText(exportResult.content);
+    setCopiedExport(true);
+    setTimeout(() => setCopiedExport(false), 2000);
+    toast.success("Bundle copied");
+  };
+
+  const handleDownloadExport = () => {
+    const exportResult = createExport();
+    if (exportResult.exportedIconCount === 0) {
+      toast.error("No exportable icons in this bundle");
+      return;
+    }
+
+    const blob = new Blob([exportResult.content], { type: exportResult.mimeType });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = exportResult.fileName;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+    toast.success(`Downloaded ${exportResult.fileName}`);
+  };
 
   return (
     <div className="min-h-screen px-4 lg:px-20 xl:px-40">
@@ -226,13 +274,73 @@ export function BundleBrowser({ bundle, categories, initialIcons, totalIconCount
             </label>
           )}
 
-          {/* Export button */}
-          <button
-            className="flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm bg-black/5 dark:bg-white/5 text-foreground hover:bg-black/10 dark:hover:bg-white/10 transition-colors ml-auto"
-          >
-            <DownloadIcon className="w-4 h-4" />
-            Export
-          </button>
+          <Popover>
+            <PopoverTrigger asChild>
+              <button
+                disabled={bundleIcons.length === 0}
+                className="flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm bg-black/5 dark:bg-white/5 text-foreground hover:bg-black/10 dark:hover:bg-white/10 transition-colors disabled:opacity-50 disabled:cursor-not-allowed ml-auto"
+              >
+                <DownloadIcon className="w-4 h-4" />
+                Export
+              </button>
+            </PopoverTrigger>
+            <PopoverContent align="end" className="w-72 p-3">
+              <div className="space-y-3">
+                <div className="grid grid-cols-3 gap-2">
+                  <button
+                    onClick={() => setExportFormat("react")}
+                    className={`flex items-center justify-center gap-1.5 px-2 py-2 rounded-md text-xs font-mono transition-colors ${
+                      exportFormat === "react"
+                        ? "bg-black text-white dark:bg-white dark:text-black"
+                        : "bg-black/5 dark:bg-white/5 text-muted-foreground hover:bg-black/10 dark:hover:bg-white/10"
+                    }`}
+                  >
+                    <FileCodeIcon className="w-3.5 h-3.5" />
+                    React
+                  </button>
+                  <button
+                    onClick={() => setExportFormat("svg")}
+                    className={`flex items-center justify-center gap-1.5 px-2 py-2 rounded-md text-xs font-mono transition-colors ${
+                      exportFormat === "svg"
+                        ? "bg-black text-white dark:bg-white dark:text-black"
+                        : "bg-black/5 dark:bg-white/5 text-muted-foreground hover:bg-black/10 dark:hover:bg-white/10"
+                    }`}
+                  >
+                    <FileCodeIcon className="w-3.5 h-3.5" />
+                    SVG
+                  </button>
+                  <button
+                    onClick={() => setExportFormat("json")}
+                    className={`flex items-center justify-center gap-1.5 px-2 py-2 rounded-md text-xs font-mono transition-colors ${
+                      exportFormat === "json"
+                        ? "bg-black text-white dark:bg-white dark:text-black"
+                        : "bg-black/5 dark:bg-white/5 text-muted-foreground hover:bg-black/10 dark:hover:bg-white/10"
+                    }`}
+                  >
+                    <FileJsonIcon className="w-3.5 h-3.5" />
+                    JSON
+                  </button>
+                </div>
+
+                <div className="flex gap-2">
+                  <button
+                    onClick={handleCopyExport}
+                    className="flex-1 flex items-center justify-center gap-2 px-3 py-2 rounded-md text-sm bg-black/10 dark:bg-white/10 hover:bg-black/15 dark:hover:bg-white/15 transition-colors"
+                  >
+                    <CopyIcon className="w-4 h-4" />
+                    {copiedExport ? "Copied" : "Copy"}
+                  </button>
+                  <button
+                    onClick={handleDownloadExport}
+                    className="flex-1 flex items-center justify-center gap-2 px-3 py-2 rounded-md text-sm bg-black/10 dark:bg-white/10 hover:bg-black/15 dark:hover:bg-white/15 transition-colors"
+                  >
+                    <DownloadIcon className="w-4 h-4" />
+                    Download
+                  </button>
+                </div>
+              </div>
+            </PopoverContent>
+          </Popover>
         </div>
       </div>
 

--- a/src/lib/bundle-export.test.ts
+++ b/src/lib/bundle-export.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import {
+  generateBundleExport,
+  getBundleExportFileName,
+  getBundleExportIcons,
+} from "./bundle-export";
+import type { BundleIcon } from "@/types/database";
+
+const baseIcon: BundleIcon = {
+  id: "lucide:arrow-right",
+  name: "Arrow Right",
+  normalizedName: "arrow-right",
+  sourceId: "lucide",
+  svg: '<path d="M5 12h14" /><path d="m12 5 7 7-7 7" />',
+  viewBox: "0 0 24 24",
+  strokeWidth: "2",
+  defaultFill: false,
+  defaultStroke: true,
+};
+
+describe("saved bundle export generation", () => {
+  it("exports saved bundle icons as React components", () => {
+    const result = generateBundleExport("Navigation Set", {
+      icons: [baseIcon],
+      format: "react",
+    });
+
+    expect(result.fileName).toBe("navigation-set.tsx");
+    expect(result.mimeType).toBe("text/plain");
+    expect(result.exportedIconCount).toBe(1);
+    expect(result.content).toContain('import type { SVGProps } from "react";');
+    expect(result.content).toContain("export function ArrowRight");
+    expect(result.content).toContain('Identifier: lucide:arrow-right');
+    expect(result.content).toContain(baseIcon.svg);
+  });
+
+  it("exports legacy bundle icons that stored SVG in content", () => {
+    const legacyIcon = {
+      ...baseIcon,
+      svg: "",
+      content: '<path d="M4 4h16v16H4z" />',
+      normalizedName: "square",
+    } as BundleIcon & { content: string };
+
+    const result = generateBundleExport("Legacy", {
+      icons: [legacyIcon],
+      format: "json",
+    });
+
+    expect(result.fileName).toBe("legacy.json");
+    expect(result.mimeType).toBe("application/json");
+    expect(JSON.parse(result.content)).toEqual([
+      expect.objectContaining({
+        name: "square",
+        content: legacyIcon.content,
+      }),
+    ]);
+  });
+
+  it("normalizes stroke width and viewBox before exporting", () => {
+    const phosphorIcon: BundleIcon = {
+      ...baseIcon,
+      id: "phosphor:bell",
+      name: "Bell",
+      normalizedName: "bell",
+      sourceId: "phosphor",
+      svg: '<path d="M128 32" stroke-width="4" />',
+      viewBox: "0 0 256 256",
+      strokeWidth: "4",
+    };
+
+    const icons = getBundleExportIcons({
+      icons: [phosphorIcon],
+      normalizeStrokes: true,
+      targetStrokeWidth: 1.5,
+      normalizeViewbox: true,
+    });
+
+    expect(icons[0]).toMatchObject({
+      viewBox: "0 0 24 24",
+      strokeWidth: "1.5",
+    });
+    expect(icons[0]?.content).toContain('d="M12 3"');
+    expect(icons[0]?.content).toContain('stroke-width="1.5"');
+  });
+
+  it("falls back to a safe filename when bundle name has no slug characters", () => {
+    expect(getBundleExportFileName("!!!", "svg")).toBe("bundle.svg");
+  });
+});

--- a/src/lib/bundle-export.ts
+++ b/src/lib/bundle-export.ts
@@ -1,0 +1,130 @@
+import {
+  generateJsonBundle,
+  generateReactFile,
+  generateSvgBundle,
+  normalizeIcons,
+  STANDARD_VIEWBOX,
+} from "@/lib/icon-utils";
+import type { BundleIcon } from "@/types/database";
+import type { IconData } from "@/types/icon";
+
+export type BundleExportFormat = "react" | "svg" | "json";
+
+interface BundleExportOptions {
+  icons: BundleIcon[];
+  format: BundleExportFormat;
+  normalizeStrokes?: boolean;
+  targetStrokeWidth?: number | null;
+  normalizeViewbox?: boolean;
+}
+
+export interface BundleExportResult {
+  content: string;
+  fileName: string;
+  mimeType: string;
+  exportedIconCount: number;
+}
+
+function getIconContent(icon: BundleIcon): string {
+  return icon.svg || (icon as unknown as { content?: string }).content || "";
+}
+
+function getDefaultViewBox(icon: BundleIcon): string {
+  return icon.sourceId === "phosphor" ? "0 0 256 256" : STANDARD_VIEWBOX;
+}
+
+function getExtension(format: BundleExportFormat): string {
+  switch (format) {
+    case "react":
+      return "tsx";
+    case "svg":
+      return "svg";
+    case "json":
+      return "json";
+  }
+}
+
+function getMimeType(format: BundleExportFormat): string {
+  switch (format) {
+    case "json":
+      return "application/json";
+    case "svg":
+      return "image/svg+xml";
+    case "react":
+      return "text/plain";
+  }
+}
+
+export function getBundleExportFileName(name: string, format: BundleExportFormat): string {
+  const slug = name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  return `${slug || "bundle"}.${getExtension(format)}`;
+}
+
+export function getBundleExportIcons(options: Omit<BundleExportOptions, "format">): IconData[] {
+  const icons = options.icons
+    .map((icon): IconData | null => {
+      const content = getIconContent(icon);
+      if (!content) return null;
+
+      return {
+        id: icon.id,
+        name: icon.name,
+        normalizedName: icon.normalizedName,
+        sourceId: icon.sourceId,
+        category: null,
+        tags: [],
+        viewBox: icon.viewBox || getDefaultViewBox(icon),
+        content,
+        pathData: null,
+        defaultStroke: icon.defaultStroke ?? true,
+        defaultFill: icon.defaultFill ?? false,
+        strokeWidth: icon.strokeWidth ?? null,
+        brandColor: null,
+      };
+    })
+    .filter((icon): icon is IconData => icon !== null);
+
+  if (!options.normalizeStrokes && !options.normalizeViewbox) {
+    return icons;
+  }
+
+  return normalizeIcons(icons, {
+    ...(options.normalizeStrokes && {
+      strokeWidth: options.targetStrokeWidth ?? 2,
+      skipFillIcons: true,
+    }),
+    ...(options.normalizeViewbox && { viewBox: STANDARD_VIEWBOX }),
+  });
+}
+
+export function generateBundleExport(
+  name: string,
+  options: BundleExportOptions
+): BundleExportResult {
+  const icons = getBundleExportIcons(options);
+  let content: string;
+
+  switch (options.format) {
+    case "react":
+      content = generateReactFile(icons);
+      break;
+    case "svg":
+      content = generateSvgBundle(icons);
+      break;
+    case "json":
+      content = generateJsonBundle(icons);
+      break;
+  }
+
+  return {
+    content,
+    fileName: getBundleExportFileName(name, options.format),
+    mimeType: getMimeType(options.format),
+    exportedIconCount: icons.length,
+  };
+}


### PR DESCRIPTION
## Summary
- wire the saved bundle Export button to actual copy/download actions
- support React, SVG, and JSON export formats for saved bundles
- reuse shared icon export generators and apply saved bundle stroke/viewBox normalization before export
- add regression coverage for export generation and the saved bundle download path

## Root Cause
The saved bundle detail page rendered an Export button with no click handler or export path. The homepage cart already had working export generation, but saved bundles never reused that functionality.

## Validation
- pnpm install --frozen-lockfile --ignore-scripts
- pnpm exec vitest run src/components/bundles/bundle-browser.test.tsx src/lib/bundle-export.test.ts
- pnpm typecheck
- pnpm lint
- pnpm test
- git diff --check

## Notes
- Browser verification against /bundles/:id needs authenticated Supabase state. The regression test covers the broken Export -> Download interaction in jsdom.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/webrenew/codesmith/unicon/pr/178"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784037201&installation_id=129242532&pr_number=178&repository=webrenew%2Funicon&return_to=https%3A%2F%2Fgithub.com%2Fwebrenew%2Funicon%2Fpull%2F178&signature=06eb5c9e7be19312ded3cd3bc597f13f2d22a65a4f70599d8a980977e635afef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->