### PR TITLE
Speed up app icon search

### DIFF
--- a/src/app/api/icons/route.test.ts
+++ b/src/app/api/icons/route.test.ts
@@ -1,8 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GET } from "./route";
 import { db } from "@/lib/db";
+import { searchIcons } from "@/lib/queries";
 import { checkPublicRateLimit } from "@/lib/rate-limit";
 import { getCachedSearchResults, setCachedSearchResults } from "@/lib/ai";
+import type { IconData } from "@/types/icon";
 
 const semanticCache = vi.hoisted(() => new Map<string, unknown>());
 
@@ -74,8 +76,27 @@ function makeSemanticRow(index: number) {
   };
 }
 
-describe("GET /api/icons semantic cache pagination", () => {
+function makeIconRow(index: number): IconData {
+  return {
+    id: `icon-${index}`,
+    name: `Icon ${index}`,
+    normalizedName: `icon-${index}`,
+    sourceId: "lucide",
+    category: "general",
+    tags: [],
+    viewBox: "0 0 24 24",
+    content: "<path d='M1 1h22v22H1z'/>",
+    pathData: null,
+    defaultStroke: true,
+    defaultFill: false,
+    strokeWidth: "2",
+    brandColor: null,
+  };
+}
+
+describe("GET /api/icons search performance paths", () => {
   const dbAllMock = vi.mocked(db.all);
+  const searchIconsMock = vi.mocked(searchIcons);
   const checkPublicRateLimitMock = vi.mocked(checkPublicRateLimit);
   const getCachedSearchResultsMock = vi.mocked(getCachedSearchResults);
   const setCachedSearchResultsMock = vi.mocked(setCachedSearchResults);
@@ -92,9 +113,29 @@ describe("GET /api/icons semantic cache pagination", () => {
     });
 
     dbAllMock.mockResolvedValue([makeSemanticRow(1), makeSemanticRow(2), makeSemanticRow(3)]);
+    searchIconsMock.mockResolvedValue([makeIconRow(1), makeIconRow(2), makeIconRow(3)]);
   });
 
-  it("stores hasMore in cache and returns consistent hasMore on cache hits", async () => {
+  it("uses fast text search when semantic search is disabled", async () => {
+    const request = new Request("https://example.com/api/icons?q=arrow&limit=2&offset=0&ai=false");
+
+    const response = await GET(request as never);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      hasMore: true,
+      searchType: "text",
+    });
+    expect(searchIconsMock).toHaveBeenCalledWith({
+      query: "arrow",
+      limit: 3,
+      offset: 0,
+    });
+    expect(dbAllMock).not.toHaveBeenCalled();
+    expect(getCachedSearchResultsMock).not.toHaveBeenCalled();
+  });
+
+  it("stores hasMore in cache and returns consistent hasMore on semantic cache hits", async () => {
     const request = new Request("https://example.com/api/icons?q=arrow&limit=2&offset=0");
 
     const firstResponse = await GET(request as never);
@@ -122,7 +163,7 @@ describe("GET /api/icons semantic cache pagination", () => {
     expect(dbAllMock).not.toHaveBeenCalled();
   });
 
-  it("defaults legacy cache entries without hasMore to hasMore=false", async () => {
+  it("defaults legacy semantic cache entries without hasMore to hasMore=false", async () => {
     semanticCache.set("search:arrow:all:2:0", {
       icons: [makeSemanticRow(1)],
       searchType: "semantic",

--- a/src/app/api/icons/route.ts
+++ b/src/app/api/icons/route.ts
@@ -74,7 +74,7 @@ export async function GET(request: NextRequest) {
     );
   }
   const { limit, offset } = parsedPagination;
-  const useAI = searchParams.get("ai") !== "false"; // AI search enabled by default
+  const useAI = searchParams.get("ai") !== "false"; // API clients get semantic search by default; app UIs can opt out.
 
   try {
     // If names parameter is provided, fetch icons by exact name match
@@ -92,7 +92,7 @@ export async function GET(request: NextRequest) {
         }
       );
     }
-    // If there's a search query, use AI-powered semantic search
+    // If there's a search query, use AI-powered semantic search unless ai=false.
     if (queryParam && queryParam.trim().length >= 3 && useAI) {
       const aiResults = await aiSemanticSearch(
         queryParam.trim(),

--- a/src/components/bundles/bundle-editor.tsx
+++ b/src/components/bundles/bundle-editor.tsx
@@ -46,7 +46,7 @@ export function BundleEditor({ bundle, onUpdate }: BundleEditorProps) {
   useEffect(() => {
     const timer = setTimeout(() => {
       setDebouncedQuery(searchQuery);
-    }, 300);
+    }, 150);
     return () => clearTimeout(timer);
   }, [searchQuery]);
 
@@ -76,7 +76,7 @@ export function BundleEditor({ bundle, onUpdate }: BundleEditorProps) {
     const doSearch = async () => {
       setIsSearching(true);
       try {
-        const params = new URLSearchParams({ q: debouncedQuery, limit: "50" });
+        const params = new URLSearchParams({ q: debouncedQuery, limit: "50", ai: "false" });
         const res = await fetch(`/api/icons?${params}`, {
           signal: controller.signal,
         });

--- a/src/components/bundles/use-bundle-browser.ts
+++ b/src/components/bundles/use-bundle-browser.ts
@@ -67,7 +67,7 @@ export function useBundleBrowser({
   useEffect(() => {
     const timer = setTimeout(() => {
       setDebouncedSearch(search);
-    }, 300);
+    }, 150);
     return () => clearTimeout(timer);
   }, [search]);
 
@@ -97,7 +97,10 @@ export function useBundleBrowser({
           limit: String(ICONS_PER_PAGE),
           offset: String(page * ICONS_PER_PAGE),
         });
-        if (debouncedSearch.trim()) params.set("q", debouncedSearch);
+        if (debouncedSearch.trim()) {
+          params.set("q", debouncedSearch);
+          params.set("ai", "false");
+        }
         if (selectedSource !== "all") params.set("source", selectedSource);
         if (selectedCategory !== "all") params.set("category", selectedCategory);
 

--- a/src/components/icons/use-icon-browser.test.tsx
+++ b/src/components/icons/use-icon-browser.test.tsx
@@ -59,47 +59,85 @@ describe("useIconBrowser request sequencing", () => {
     iconSearchCache.clear();
   });
 
-  it("ignores a stale unfiltered response that resolves after a newer filtered one", async () => {
-    const { result } = renderHook(() => useIconBrowser({ initialIcons: [], totalCount: 0 }));
+  it("uses the server-rendered first page without a duplicate fetch", async () => {
+    const initialIcons = [makeIcon("lucide-a", "lucide"), makeIcon("tabler-b", "tabler")];
 
-    // Mount triggers the initial, unfiltered fetch.
-    await waitFor(() => expect(pending).toHaveLength(1));
-    const staleRequest = pending[0]!;
-    expect(staleRequest.url).not.toContain("source=");
-
-    // User picks a library while the first request is still in flight.
-    await act(async () => {
-      result.current.setSelectedSource("remix");
-    });
-    await waitFor(() => expect(pending).toHaveLength(2));
-    const remixRequest = pending[1]!;
-    expect(remixRequest.url).toContain("source=remix");
-
-    // The newer (filtered) request resolves first.
-    await act(async () => {
-      remixRequest.resolve([makeIcon("remix-a", "remix"), makeIcon("remix-b", "remix")]);
-    });
-    await waitFor(() =>
-      expect(result.current.icons.map((icon) => icon.id)).toEqual(["remix-a", "remix-b"]),
+    const { result } = renderHook(() =>
+      useIconBrowser({ initialIcons, totalCount: initialIcons.length }),
     );
 
-    // The older (unfiltered) request resolves afterwards — it must not clobber state.
+    expect(result.current.icons.map((icon) => icon.id)).toEqual(["lucide-a", "tabler-b"]);
+
     await act(async () => {
-      staleRequest.resolve([makeIcon("lucide-x", "lucide"), makeIcon("tabler-y", "tabler")]);
       await tick();
     });
 
-    expect(result.current.icons.map((icon) => icon.id)).toEqual(["remix-a", "remix-b"]);
-    expect(result.current.icons.every((icon) => icon.sourceId === "remix")).toBe(true);
+    expect(pending).toHaveLength(0);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("requests fast text mode for typed searches", async () => {
+    const { result } = renderHook(() => useIconBrowser({ initialIcons: [], totalCount: 0 }));
+
+    await act(async () => {
+      result.current.setSearch("arrow");
+    });
+
+    await waitFor(() => expect(pending).toHaveLength(1));
+    expect(pending[0]!.url).toContain("q=arrow");
+    expect(pending[0]!.url).toContain("ai=false");
+
+    await act(async () => {
+      pending[0]!.resolve([makeIcon("arrow", "lucide")]);
+    });
+  });
+
+  it("ignores a stale filtered response that resolves after a newer filtered one", async () => {
+    const { result } = renderHook(() => useIconBrowser({ initialIcons: [], totalCount: 0 }));
+
+    await act(async () => {
+      result.current.setSelectedSource("remix");
+    });
+    await waitFor(() => expect(pending).toHaveLength(1));
+    const staleRequest = pending[0]!;
+    expect(staleRequest.url).toContain("source=remix");
+
+    await act(async () => {
+      result.current.setSelectedSource("lucide");
+    });
+    await waitFor(() => expect(pending).toHaveLength(2));
+    const lucideRequest = pending[1]!;
+    expect(lucideRequest.url).toContain("source=lucide");
+
+    // The newer (filtered) request resolves first.
+    await act(async () => {
+      lucideRequest.resolve([makeIcon("lucide-a", "lucide"), makeIcon("lucide-b", "lucide")]);
+    });
+    await waitFor(() =>
+      expect(result.current.icons.map((icon) => icon.id)).toEqual(["lucide-a", "lucide-b"]),
+    );
+
+    // The older filtered request resolves afterwards — it must not clobber state.
+    await act(async () => {
+      staleRequest.resolve([makeIcon("remix-x", "remix"), makeIcon("remix-y", "remix")]);
+      await tick();
+    });
+
+    expect(result.current.icons.map((icon) => icon.id)).toEqual(["lucide-a", "lucide-b"]);
+    expect(result.current.icons.every((icon) => icon.sourceId === "lucide")).toBe(true);
     expect(result.current.isLoading).toBe(false);
   });
 
   it("swallows AbortError from a superseded request and applies the current one", async () => {
     const { result } = renderHook(() => useIconBrowser({ initialIcons: [], totalCount: 0 }));
-    await waitFor(() => expect(pending).toHaveLength(1));
 
     await act(async () => {
       result.current.setSelectedSource("remix");
+    });
+    await waitFor(() => expect(pending).toHaveLength(1));
+
+    await act(async () => {
+      result.current.setSelectedSource("lucide");
     });
     await waitFor(() => expect(pending).toHaveLength(2));
 
@@ -111,9 +149,9 @@ describe("useIconBrowser request sequencing", () => {
 
     // The current request still resolves and updates state normally.
     await act(async () => {
-      pending[1]!.resolve([makeIcon("remix-a", "remix")]);
+      pending[1]!.resolve([makeIcon("lucide-a", "lucide")]);
     });
-    await waitFor(() => expect(result.current.icons.map((icon) => icon.id)).toEqual(["remix-a"]));
+    await waitFor(() => expect(result.current.icons.map((icon) => icon.id)).toEqual(["lucide-a"]));
     expect(result.current.isLoading).toBe(false);
   });
 });

--- a/src/components/icons/use-icon-browser.ts
+++ b/src/components/icons/use-icon-browser.ts
@@ -25,7 +25,10 @@ function buildIconSearchParams(opts: {
     limit: String(opts.limit),
     offset: String(opts.offset),
   });
-  if (opts.query) params.set("q", opts.query);
+  if (opts.query) {
+    params.set("q", opts.query);
+    params.set("ai", "false");
+  }
   if (opts.source && opts.source !== "all") params.set("source", opts.source);
   if (opts.category && opts.category !== "all") params.set("category", opts.category);
   return params;
@@ -264,7 +267,7 @@ export function useIconBrowser({ initialIcons, totalCount }: UseIconBrowserParam
   useEffect(() => {
     const timer = setTimeout(() => {
       setDebouncedSearch(search);
-    }, 300);
+    }, 150);
     return () => clearTimeout(timer);
   }, [search]);
 
@@ -298,6 +301,21 @@ export function useIconBrowser({ initialIcons, totalCount }: UseIconBrowserParam
       // A newer request supersedes any in-flight one.
       abortRef.current?.abort();
       abortRef.current = null;
+
+      const isDefaultFirstPage =
+        pageNum === 0 &&
+        debouncedSearch.length === 0 &&
+        selectedSource === "all" &&
+        selectedCategory === "all";
+
+      if (isDefaultFirstPage) {
+        setIcons(initialIcons.slice(0, ICONS_PER_PAGE));
+        setSearchType("text");
+        setExpandedQuery(null);
+        setTotalResults(totalCount);
+        setIsLoading(false);
+        return;
+      }
 
       const cacheKey = {
         q: debouncedSearch || '',
@@ -345,7 +363,7 @@ export function useIconBrowser({ initialIcons, totalCount }: UseIconBrowserParam
         if (isCurrent()) setIsLoading(false);
       }
     },
-    [debouncedSearch, selectedSource, selectedCategory]
+    [debouncedSearch, selectedSource, selectedCategory, initialIcons, totalCount]
   );
 
   // Use a ref for fetchIcons to avoid stale closures in effects without adding


### PR DESCRIPTION
## Summary
- make app icon-search requests use the existing `ai=false` fast text-search path while preserving the public API semantic-search default
- reduce interactive search debounce from 300ms to 150ms in homepage and bundle search surfaces
- skip the redundant homepage first-page client fetch when server-rendered icons already cover the default view

## Validation
- `pnpm exec vitest run src/app/api/icons/route.test.ts src/components/icons/use-icon-browser.test.tsx`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `git diff --check`

## Build note
- `pnpm build` compiled successfully and completed TypeScript, then failed during page-data collection because `TURSO_DATABASE_URL` is not set in the local worktree.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/webrenew/codesmith/unicon/pr/179"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784040658&installation_id=129242532&pr_number=179&repository=webrenew%2Funicon&return_to=https%3A%2F%2Fgithub.com%2Fwebrenew%2Funicon%2Fpull%2F179&signature=63c01c60e6185223ca12b3bb58284d88df7a54e36f2012eb4c8b1ea7d7359972"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->