### PR TITLE
Address search performance review feedback

### DIFF
--- a/src/app/api/icons/route.ts
+++ b/src/app/api/icons/route.ts
@@ -74,7 +74,7 @@ export async function GET(request: NextRequest) {
     );
   }
   const { limit, offset } = parsedPagination;
-  const useAI = searchParams.get("ai") !== "false"; // API clients get semantic search by default; app UIs can opt out.
+  const useAI = searchParams.get("ai") !== "false"; // GET /api/icons is semantic by default; pass ai=false for low-latency text search.
 
   try {
     // If names parameter is provided, fetch icons by exact name match

--- a/src/components/bundles/bundle-browser.test.tsx
+++ b/src/components/bundles/bundle-browser.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { BundleBrowser } from "./bundle-browser";
 import type { Bundle } from "@/types/database";
@@ -57,6 +57,7 @@ describe("BundleBrowser export", () => {
   });
 
   afterEach(() => {
+    cleanup();
     clickAnchor.mockRestore();
     vi.unstubAllGlobals();
   });
@@ -79,5 +80,35 @@ describe("BundleBrowser export", () => {
     expect(createObjectURL).toHaveBeenCalledWith(expect.any(Blob));
     expect(clickAnchor).toHaveBeenCalled();
     expect(revokeObjectURL).toHaveBeenCalledWith("blob:bundle-export");
+  });
+
+  it("requests fast text mode when searching for icons to add", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ icons: [], total: 0, searchType: "text" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <BundleBrowser
+        bundle={bundle}
+        categories={[]}
+        initialIcons={[]}
+        totalIconCount={0}
+        countBySource={{}}
+        onUpdate={vi.fn()}
+      />
+    );
+
+    fireEvent.change(screen.getByPlaceholderText("Search icons to add to your bundle..."), {
+      target: { value: "arrow" },
+    });
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    const [url] = fetchMock.mock.calls[0]!;
+    expect(url).toContain("q=arrow");
+    expect(url).toContain("ai=false");
   });
 });

--- a/src/components/icons/use-icon-browser.test.tsx
+++ b/src/components/icons/use-icon-browser.test.tsx
@@ -62,8 +62,11 @@ describe("useIconBrowser request sequencing", () => {
   it("uses the server-rendered first page without a duplicate fetch", async () => {
     const initialIcons = [makeIcon("lucide-a", "lucide"), makeIcon("tabler-b", "tabler")];
 
-    const { result } = renderHook(() =>
-      useIconBrowser({ initialIcons, totalCount: initialIcons.length }),
+    const { result, rerender } = renderHook(
+      ({ icons, totalCount }) => useIconBrowser({ initialIcons: icons, totalCount }),
+      {
+        initialProps: { icons: initialIcons, totalCount: initialIcons.length },
+      },
     );
 
     expect(result.current.icons.map((icon) => icon.id)).toEqual(["lucide-a", "tabler-b"]);
@@ -72,6 +75,13 @@ describe("useIconBrowser request sequencing", () => {
       await tick();
     });
 
+    rerender({ icons: [...initialIcons], totalCount: initialIcons.length });
+
+    await act(async () => {
+      await tick();
+    });
+
+    expect(result.current.icons.map((icon) => icon.id)).toEqual(["lucide-a", "tabler-b"]);
     expect(pending).toHaveLength(0);
     expect(global.fetch).not.toHaveBeenCalled();
   });

--- a/src/components/icons/use-icon-browser.ts
+++ b/src/components/icons/use-icon-browser.ts
@@ -62,6 +62,8 @@ export function useIconBrowser({ initialIcons, totalCount }: UseIconBrowserParam
   const [isLoading, setIsLoading] = useState(false);
   const [searchType, setSearchType] = useState<string>("text");
   const [expandedQuery, setExpandedQuery] = useState<string | null>(null);
+  const initialPageIconsRef = useRef(initialIcons.slice(0, ICONS_PER_PAGE));
+  const initialTotalCountRef = useRef(totalCount);
 
   // Display presets - persisted to localStorage
   const [strokePreset, setStrokePreset] = useState<StrokePreset>("regular");
@@ -309,10 +311,10 @@ export function useIconBrowser({ initialIcons, totalCount }: UseIconBrowserParam
         selectedCategory === "all";
 
       if (isDefaultFirstPage) {
-        setIcons(initialIcons.slice(0, ICONS_PER_PAGE));
+        setIcons(initialPageIconsRef.current);
         setSearchType("text");
         setExpandedQuery(null);
-        setTotalResults(totalCount);
+        setTotalResults(initialTotalCountRef.current);
         setIsLoading(false);
         return;
       }
@@ -363,7 +365,7 @@ export function useIconBrowser({ initialIcons, totalCount }: UseIconBrowserParam
         if (isCurrent()) setIsLoading(false);
       }
     },
-    [debouncedSearch, selectedSource, selectedCategory, initialIcons, totalCount]
+    [debouncedSearch, selectedSource, selectedCategory]
   );
 
   // Use a ref for fetchIcons to avoid stale closures in effects without adding


### PR DESCRIPTION
## Summary
- remove unstable `initialIcons` / `totalCount` dependencies from homepage search fetching by treating the SSR first page as a mounted-instance seed
- clarify that `ai=false` is the explicit low-latency text-search opt-out for `GET /api/icons`
- add bundle browser regression coverage that typed icon lookup sends `ai=false`

## Review threads addressed
- Mogplex: `fetchIcons` dependency array may cause spurious re-fetches
- Mogplex: route comment should explicitly mention `ai=false`
- Mogplex: bundle search should have `ai=false` coverage

## Validation
- `pnpm exec vitest run src/components/icons/use-icon-browser.test.tsx src/components/bundles/bundle-browser.test.tsx src/app/api/icons/route.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `git diff --check`

## Build note
- `pnpm build` compiled successfully and completed TypeScript, then failed during page-data collection because `TURSO_DATABASE_URL` is not set in the local worktree.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/webrenew/codesmith/unicon/pr/180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784043268&installation_id=129242532&pr_number=180&repository=webrenew%2Funicon&return_to=https%3A%2F%2Fgithub.com%2Fwebrenew%2Funicon%2Fpull%2F180&signature=41deccba3e3270fd7f6f609ce9fa2bad09bd5dd8dfd15c0fabcd76000ecaf237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->