### PR TITLE
fix(test): register RTL cleanup in vitest setup to stop leaked-timer flake

### DIFF
--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -1,1 +1,11 @@
 import "@testing-library/jest-dom/vitest";
+import { cleanup } from "@testing-library/react";
+import { afterEach } from "vitest";
+
+// Vitest runs with globals disabled, so React Testing Library cannot register
+// its automatic cleanup. Without this, components stay mounted after each test
+// and pending timers (e.g. the 150ms search debounce in use-icon-browser) fire
+// setState after jsdom teardown, failing CI with "window is not defined".
+afterEach(() => {
+  cleanup();
+});


### PR DESCRIPTION
## Problem
The **Test Coverage** job intermittently fails with all tests passing but one unhandled error:

```
ReferenceError: window is not defined
 ❯ Timeout._onTimeout src/components/icons/use-icon-browser.ts:271:7
```

## Root cause
The hook itself is fine — its debounce effect clears the timer on unmount. But the components were **never unmounted**: `vitest.config.ts` runs with `globals` disabled, which prevents `@testing-library/react` from self-registering its automatic `afterEach` cleanup, and the setup file didn't call `cleanup()` either. Rendered hooks stayed mounted until jsdom teardown, so on slow runners the still-pending 150ms search-debounce `setTimeout` fired `setState` into a dead environment.

## Fix
Register `afterEach(cleanup)` in `src/__tests__/setup.ts`. Cleanup unmounts after every test, which runs the effect cleanup that clears the timer — deterministic, and it also protects every other test file from the same class of leak.

Verified locally: 126/126 tests pass, typecheck clean.

Fixes #194

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/webrenew/codesmith/unicon/pr/197"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786893121&installation_id=129242532&pr_number=197&repository=webrenew%2Funicon&return_to=https%3A%2F%2Fgithub.com%2Fwebrenew%2Funicon%2Fpull%2F197&signature=cdad488eecf4ac2d97f402bc76340ff89a7e13836d0df6f544d5b356fea320bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->