### PR TITLE
ci: block production builds on Supabase schema drift

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "scripts": {
     "dev": "next dev",
-    "build": "next build --webpack",
+    "build": "pnpm schema:check:production && next build --webpack",
     "start": "next start",
     "lint": "eslint",
     "typecheck": "tsc --noEmit",
@@ -40,6 +40,7 @@
     "embeddings:stats": "tsx scripts/generate-embeddings.ts --stats",
     "cache:warm": "tsx scripts/warm-cache.ts",
     "cache:warm:prod": "tsx scripts/warm-cache.ts --url=https://unicon.sh",
+    "schema:check:production": "tsx scripts/check-production-schema.ts",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
       "qs": "6.15.2",
       "ip-address": "10.1.1",
       "postcss": "8.5.15",
-      "brace-expansion": "5.0.6",
+      "brace-expansion": "5.0.7",
       "yaml": "2.9.0",
       "ajv@^6": "6.14.0",
       "@opentelemetry/core@<2.8.0": ">=2.8.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ overrides:
   qs: 6.15.2
   ip-address: 10.1.1
   postcss: 8.5.15
-  brace-expansion: 5.0.6
+  brace-expansion: 5.0.7
   yaml: 2.9.0
   ajv@^6: 6.14.0
   '@opentelemetry/core@<2.8.0': '>=2.8.0'
@@ -2746,8 +2746,8 @@ packages:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -7690,7 +7690,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -9147,11 +9147,11 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minimist@1.2.8: {}
 

--- a/scripts/check-production-schema.ts
+++ b/scripts/check-production-schema.ts
@@ -1,0 +1,18 @@
+import { checkProductionSupabaseSchema } from "../src/lib/supabase/production-schema";
+
+async function main() {
+  const result = await checkProductionSupabaseSchema();
+
+  if (!result.checked) {
+    console.log("Production Supabase schema check skipped outside Vercel production.");
+    return;
+  }
+
+  console.log(`Production Supabase schema check passed (${result.pathCount} paths).`);
+}
+
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : "Unknown production schema check error";
+  console.error(message);
+  process.exitCode = 1;
+});

--- a/scripts/check-production-schema.ts
+++ b/scripts/check-production-schema.ts
@@ -1,6 +1,26 @@
-import { checkProductionSupabaseSchema } from "../src/lib/supabase/production-schema";
+import {
+  collectSupabaseSchemaPaths,
+  findMissingSupabaseContractPaths,
+} from "./lib/supabase-source-contract";
+import {
+  checkProductionSupabaseSchema,
+  REQUIRED_SUPABASE_PATHS,
+} from "../src/lib/supabase/production-schema";
 
 async function main() {
+  const sourcePaths = collectSupabaseSchemaPaths(process.cwd());
+  const missingContractPaths = findMissingSupabaseContractPaths(
+    sourcePaths,
+    REQUIRED_SUPABASE_PATHS
+  );
+  if (missingContractPaths.length > 0) {
+    throw new Error(
+      `Supabase source contract is missing required paths: ${missingContractPaths.join(", ")}`
+    );
+  }
+
+  console.log(`Supabase source contract check passed (${sourcePaths.size} paths).`);
+
   const result = await checkProductionSupabaseSchema();
 
   if (!result.checked) {

--- a/scripts/lib/supabase-source-contract.ts
+++ b/scripts/lib/supabase-source-contract.ts
@@ -1,0 +1,158 @@
+import { createRequire } from "node:module";
+import { isAbsolute, relative, resolve, sep } from "node:path";
+import type {
+  CallExpression,
+  Diagnostic,
+  Expression,
+  Node,
+  SourceFile,
+  TypeChecker,
+} from "typescript";
+
+const require = createRequire(import.meta.url);
+const ts = require("typescript") as typeof import("typescript");
+
+type SupabaseSchemaMethod = "from" | "rpc";
+
+function getSchemaMethod(call: CallExpression): SupabaseSchemaMethod | null {
+  if (!ts.isPropertyAccessExpression(call.expression)) {
+    return null;
+  }
+
+  const method = call.expression.name.text;
+  return method === "from" || method === "rpc" ? method : null;
+}
+
+function getStaticString(expression: Expression | undefined): string | null {
+  if (expression && (ts.isStringLiteral(expression) || ts.isNoSubstitutionTemplateLiteral(expression))) {
+    return expression.text;
+  }
+
+  return null;
+}
+
+function getCallLocation(sourceFile: SourceFile, call: CallExpression): string {
+  const { line } = sourceFile.getLineAndCharacterOfPosition(call.getStart(sourceFile));
+  return `${sourceFile.fileName}:${line + 1}`;
+}
+
+function collectPathsFromSourceFile(
+  sourceFile: SourceFile,
+  isSupabaseCall: (call: CallExpression) => boolean
+): Set<string> {
+  const paths = new Set<string>();
+
+  const visit = (node: Node): void => {
+    if (ts.isCallExpression(node)) {
+      const method = getSchemaMethod(node);
+      if (method && isSupabaseCall(node)) {
+        const name = getStaticString(node.arguments[0]);
+        if (!name) {
+          throw new Error(
+            `Supabase .${method}() in ${getCallLocation(sourceFile, node)} must use a static string literal`
+          );
+        }
+
+        paths.add(method === "rpc" ? `/rpc/${name}` : `/${name}`);
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  return paths;
+}
+
+export function collectStaticSupabasePathsFromSource(
+  source: string,
+  fileName = "inline-source.ts"
+): Set<string> {
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS
+  );
+  return collectPathsFromSourceFile(sourceFile, () => true);
+}
+
+function isApplicationSourceFile(fileName: string, sourceRoot: string): boolean {
+  const relativePath = relative(sourceRoot, fileName);
+  return (
+    relativePath !== "" &&
+    !relativePath.startsWith(`..${sep}`) &&
+    !isAbsolute(relativePath) &&
+    !/\.(?:test|spec)\.[cm]?tsx?$/.test(relativePath)
+  );
+}
+
+function isSupabaseClientCall(call: CallExpression, checker: TypeChecker): boolean {
+  if (!ts.isPropertyAccessExpression(call.expression)) {
+    return false;
+  }
+
+  const signature = checker.getResolvedSignature(call);
+  const symbol = checker.getSymbolAtLocation(call.expression.name);
+  const declaration =
+    signature?.declaration ?? symbol?.valueDeclaration ?? symbol?.declarations?.[0];
+  const declarationFile = declaration?.getSourceFile().fileName.replaceAll("\\", "/");
+
+  return declarationFile?.includes("/node_modules/@supabase/supabase-js/") ?? false;
+}
+
+function formatDiagnostic(diagnostic: Diagnostic): string {
+  return ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n");
+}
+
+export function collectSupabaseSchemaPaths(projectRoot: string): Set<string> {
+  const resolvedProjectRoot = resolve(projectRoot);
+  const configPath = resolve(resolvedProjectRoot, "tsconfig.json");
+  const config = ts.readConfigFile(configPath, ts.sys.readFile);
+  if (config.error) {
+    throw new Error(`Could not read TypeScript config: ${formatDiagnostic(config.error)}`);
+  }
+
+  const parsedConfig = ts.parseJsonConfigFileContent(
+    config.config,
+    ts.sys,
+    resolvedProjectRoot,
+    { noEmit: true },
+    configPath
+  );
+  if (parsedConfig.errors.length > 0) {
+    throw new Error(
+      `Could not parse TypeScript config: ${parsedConfig.errors.map(formatDiagnostic).join("; ")}`
+    );
+  }
+
+  const program = ts.createProgram(parsedConfig.fileNames, parsedConfig.options);
+  const checker = program.getTypeChecker();
+  const sourceRoot = resolve(resolvedProjectRoot, "src");
+  const paths = new Set<string>();
+  let supabaseCallCount = 0;
+
+  for (const sourceFile of program.getSourceFiles()) {
+    if (!isApplicationSourceFile(sourceFile.fileName, sourceRoot)) {
+      continue;
+    }
+
+    const sourcePaths = collectPathsFromSourceFile(sourceFile, (call) => {
+      const isSupabaseCall = isSupabaseClientCall(call, checker);
+      if (isSupabaseCall) {
+        supabaseCallCount += 1;
+      }
+      return isSupabaseCall;
+    });
+    for (const path of sourcePaths) {
+      paths.add(path);
+    }
+  }
+
+  if (supabaseCallCount === 0) {
+    throw new Error("Supabase source contract scan found no Supabase schema calls");
+  }
+
+  return paths;
+}

--- a/scripts/lib/supabase-source-contract.ts
+++ b/scripts/lib/supabase-source-contract.ts
@@ -78,6 +78,14 @@ export function collectStaticSupabasePathsFromSource(
   return collectPathsFromSourceFile(sourceFile, () => true);
 }
 
+export function findMissingSupabaseContractPaths(
+  runtimePaths: Iterable<string>,
+  requiredPaths: readonly string[]
+): string[] {
+  const requiredPathSet = new Set(requiredPaths);
+  return [...runtimePaths].filter((path) => !requiredPathSet.has(path)).sort();
+}
+
 function isApplicationSourceFile(fileName: string, sourceRoot: string): boolean {
   const relativePath = relative(sourceRoot, fileName);
   return (

--- a/src/lib/supabase/production-schema.test.ts
+++ b/src/lib/supabase/production-schema.test.ts
@@ -1,6 +1,8 @@
-import { readdirSync, readFileSync } from "node:fs";
-import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
+import {
+  collectStaticSupabasePathsFromSource,
+  collectSupabaseSchemaPaths,
+} from "../../../scripts/lib/supabase-source-contract";
 import {
   checkProductionSupabaseSchema,
   REQUIRED_SUPABASE_PATHS,
@@ -22,43 +24,36 @@ const productionEnvironment = {
   SUPABASE_SERVICE_ROLE_KEY: "service-role-key",
 };
 
+describe("Supabase source contract scanner", () => {
+  it("collects multiline and static template-literal arguments", () => {
+    const paths = collectStaticSupabasePathsFromSource(`
+      supabase.from(
+        "multiline_table"
+      );
+      supabase.rpc(\`static_rpc\`);
+    `);
+
+    expect([...paths].sort()).toEqual(["/multiline_table", "/rpc/static_rpc"]);
+  });
+
+  it.each([
+    ["a variable", 'const table = "profiles"; supabase.from(table);', ".from()"],
+    ["an interpolated template", "supabase.rpc(`lookup_${kind}`);", ".rpc()"],
+  ])("fails closed when a Supabase call uses %s", (_description, source, method) => {
+    expect(() => collectStaticSupabasePathsFromSource(source, "dynamic-call.ts")).toThrow(
+      `Supabase ${method} in dynamic-call.ts:1 must use a static string literal`
+    );
+  });
+});
+
 describe("checkProductionSupabaseSchema", () => {
   it("covers every Supabase table and RPC referenced by application code", () => {
-    const storageBuckets = new Set(["team-logos"]);
-    const sourceFiles: string[] = [];
-    const collectSourceFiles = (directory: string) => {
-      for (const entry of readdirSync(directory, { withFileTypes: true })) {
-        const path = join(directory, entry.name);
-        if (entry.isDirectory()) {
-          collectSourceFiles(path);
-        } else if (/\.(ts|tsx)$/.test(entry.name) && !/\.test\.(ts|tsx)$/.test(entry.name)) {
-          sourceFiles.push(path);
-        }
-      }
-    };
-    collectSourceFiles(join(process.cwd(), "src"));
-
-    const runtimePaths = new Set<string>();
-    for (const file of sourceFiles) {
-      const source = readFileSync(file, "utf8");
-      for (const match of source.matchAll(/\.from\(["']([^"']+)["']\)/g)) {
-        const table = match[1];
-        if (table && !storageBuckets.has(table)) {
-          runtimePaths.add(`/${table}`);
-        }
-      }
-      for (const match of source.matchAll(/\.rpc\(["']([^"']+)["']/g)) {
-        const rpc = match[1];
-        if (rpc) {
-          runtimePaths.add(`/rpc/${rpc}`);
-        }
-      }
-    }
+    const runtimePaths = collectSupabaseSchemaPaths(process.cwd());
 
     const requiredPaths = new Set<string>(REQUIRED_SUPABASE_PATHS);
     const missingContractPaths = [...runtimePaths].filter((path) => !requiredPaths.has(path)).sort();
     expect(missingContractPaths).toEqual([]);
-  });
+  }, 15_000);
 
   it("skips live schema access outside production deployments", async () => {
     const fetchImpl = vi.fn();

--- a/src/lib/supabase/production-schema.test.ts
+++ b/src/lib/supabase/production-schema.test.ts
@@ -1,0 +1,139 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import {
+  checkProductionSupabaseSchema,
+  REQUIRED_SUPABASE_PATHS,
+} from "./production-schema";
+
+function createSchemaResponse(paths: string[], status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: vi.fn().mockResolvedValue({
+      paths: Object.fromEntries(paths.map((path) => [path, {}])),
+    }),
+  } as unknown as Response;
+}
+
+const productionEnvironment = {
+  VERCEL_ENV: "production",
+  NEXT_PUBLIC_SUPABASE_URL: "https://project.supabase.co",
+  SUPABASE_SERVICE_ROLE_KEY: "service-role-key",
+};
+
+describe("checkProductionSupabaseSchema", () => {
+  it("covers every Supabase table and RPC referenced by application code", () => {
+    const storageBuckets = new Set(["team-logos"]);
+    const sourceFiles: string[] = [];
+    const collectSourceFiles = (directory: string) => {
+      for (const entry of readdirSync(directory, { withFileTypes: true })) {
+        const path = join(directory, entry.name);
+        if (entry.isDirectory()) {
+          collectSourceFiles(path);
+        } else if (/\.(ts|tsx)$/.test(entry.name) && !/\.test\.(ts|tsx)$/.test(entry.name)) {
+          sourceFiles.push(path);
+        }
+      }
+    };
+    collectSourceFiles(join(process.cwd(), "src"));
+
+    const runtimePaths = new Set<string>();
+    for (const file of sourceFiles) {
+      const source = readFileSync(file, "utf8");
+      for (const match of source.matchAll(/\.from\(["']([^"']+)["']\)/g)) {
+        const table = match[1];
+        if (table && !storageBuckets.has(table)) {
+          runtimePaths.add(`/${table}`);
+        }
+      }
+      for (const match of source.matchAll(/\.rpc\(["']([^"']+)["']/g)) {
+        const rpc = match[1];
+        if (rpc) {
+          runtimePaths.add(`/rpc/${rpc}`);
+        }
+      }
+    }
+
+    const requiredPaths = new Set<string>(REQUIRED_SUPABASE_PATHS);
+    const missingContractPaths = [...runtimePaths].filter((path) => !requiredPaths.has(path)).sort();
+    expect(missingContractPaths).toEqual([]);
+  });
+
+  it("skips live schema access outside production deployments", async () => {
+    const fetchImpl = vi.fn();
+
+    await expect(
+      checkProductionSupabaseSchema({
+        env: { VERCEL_ENV: "preview" },
+        fetchImpl,
+      })
+    ).resolves.toEqual({ checked: false, pathCount: 0 });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("requires the production Supabase environment variables", async () => {
+    await expect(
+      checkProductionSupabaseSchema({
+        env: { VERCEL_ENV: "production" },
+      })
+    ).rejects.toThrow(
+      "Production schema check is missing environment variables: NEXT_PUBLIC_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY"
+    );
+  });
+
+  it("validates required paths using the server-only credential", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(createSchemaResponse(["/subscriptions", "/stripe_webhook_events"]));
+
+    await expect(
+      checkProductionSupabaseSchema({
+        env: productionEnvironment,
+        fetchImpl,
+        requiredPaths: ["/subscriptions", "/stripe_webhook_events"],
+      })
+    ).resolves.toEqual({ checked: true, pathCount: 2 });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const firstCall = fetchImpl.mock.calls[0];
+    if (!firstCall) {
+      throw new Error("Expected schema fetch call");
+    }
+    const [url, init] = firstCall;
+    expect(String(url)).toBe("https://project.supabase.co/rest/v1/");
+    const headers = new Headers(init?.headers);
+    expect(headers.get("accept")).toBe("application/openapi+json");
+    expect(headers.get("authorization")).toBe("Bearer service-role-key");
+    expect(headers.get("apikey")).toBe("service-role-key");
+  });
+
+  it("fails with every missing table or RPC path", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(createSchemaResponse(["/subscriptions"]));
+
+    await expect(
+      checkProductionSupabaseSchema({
+        env: productionEnvironment,
+        fetchImpl,
+        requiredPaths: [
+          "/subscriptions",
+          "/stripe_webhook_events",
+          "/rpc/accept_team_invite_atomic",
+        ],
+      })
+    ).rejects.toThrow(
+      "Production Supabase schema is missing required paths: /stripe_webhook_events, /rpc/accept_team_invite_atomic"
+    );
+  });
+
+  it("fails closed when the live schema cannot be read", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(createSchemaResponse([], 503));
+
+    await expect(
+      checkProductionSupabaseSchema({
+        env: productionEnvironment,
+        fetchImpl,
+      })
+    ).rejects.toThrow("Could not read production Supabase schema: HTTP 503");
+  });
+});

--- a/src/lib/supabase/production-schema.test.ts
+++ b/src/lib/supabase/production-schema.test.ts
@@ -1,12 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   collectStaticSupabasePathsFromSource,
-  collectSupabaseSchemaPaths,
+  findMissingSupabaseContractPaths,
 } from "../../../scripts/lib/supabase-source-contract";
-import {
-  checkProductionSupabaseSchema,
-  REQUIRED_SUPABASE_PATHS,
-} from "./production-schema";
+import { checkProductionSupabaseSchema } from "./production-schema";
 
 function createSchemaResponse(paths: string[], status = 200): Response {
   return {
@@ -44,17 +41,18 @@ describe("Supabase source contract scanner", () => {
       `Supabase ${method} in dynamic-call.ts:1 must use a static string literal`
     );
   });
+
+  it("reports source paths that are absent from the required contract", () => {
+    expect(
+      findMissingSupabaseContractPaths(
+        new Set(["/profiles", "/rpc/missing_rpc", "/missing_table"]),
+        ["/profiles"]
+      )
+    ).toEqual(["/missing_table", "/rpc/missing_rpc"]);
+  });
 });
 
 describe("checkProductionSupabaseSchema", () => {
-  it("covers every Supabase table and RPC referenced by application code", () => {
-    const runtimePaths = collectSupabaseSchemaPaths(process.cwd());
-
-    const requiredPaths = new Set<string>(REQUIRED_SUPABASE_PATHS);
-    const missingContractPaths = [...runtimePaths].filter((path) => !requiredPaths.has(path)).sort();
-    expect(missingContractPaths).toEqual([]);
-  }, 15_000);
-
   it("skips live schema access outside production deployments", async () => {
     const fetchImpl = vi.fn();
 

--- a/src/lib/supabase/production-schema.ts
+++ b/src/lib/supabase/production-schema.ts
@@ -1,0 +1,110 @@
+export const REQUIRED_SUPABASE_PATHS = [
+  "/api_sessions",
+  "/bundles",
+  "/device_codes",
+  "/profiles",
+  "/stripe_webhook_events",
+  "/subscriptions",
+  "/team_invites",
+  "/team_members",
+  "/teams",
+  "/rpc/accept_team_invite_atomic",
+  "/rpc/authorize_device_code",
+  "/rpc/check_device_code",
+  "/rpc/create_api_token_direct",
+  "/rpc/create_bundle_atomic",
+  "/rpc/create_device_code",
+  "/rpc/generate_invite_token",
+  "/rpc/generate_share_slug",
+  "/rpc/generate_team_slug",
+  "/rpc/list_api_sessions",
+  "/rpc/revoke_api_session",
+  "/rpc/validate_api_token",
+] as const;
+
+interface SchemaCheckEnvironment {
+  VERCEL_ENV?: string;
+  NEXT_PUBLIC_SUPABASE_URL?: string;
+  SUPABASE_SERVICE_ROLE_KEY?: string;
+}
+
+interface ProductionSchemaCheckOptions {
+  env?: SchemaCheckEnvironment;
+  fetchImpl?: typeof fetch;
+  requiredPaths?: readonly string[];
+}
+
+export interface ProductionSchemaCheckResult {
+  checked: boolean;
+  pathCount: number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export async function checkProductionSupabaseSchema({
+  env = process.env as SchemaCheckEnvironment,
+  fetchImpl = fetch,
+  requiredPaths = REQUIRED_SUPABASE_PATHS,
+}: ProductionSchemaCheckOptions = {}): Promise<ProductionSchemaCheckResult> {
+  if (env.VERCEL_ENV !== "production") {
+    return { checked: false, pathCount: 0 };
+  }
+
+  const supabaseUrl = env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = env.SUPABASE_SERVICE_ROLE_KEY;
+  const missingEnvironmentVariables = [
+    !supabaseUrl && "NEXT_PUBLIC_SUPABASE_URL",
+    !serviceRoleKey && "SUPABASE_SERVICE_ROLE_KEY",
+  ].filter(Boolean);
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error(
+      `Production schema check is missing environment variables: ${missingEnvironmentVariables.join(", ")}`
+    );
+  }
+
+  const schemaUrl = new URL("/rest/v1/", supabaseUrl);
+  if (schemaUrl.protocol !== "https:") {
+    throw new Error("Production Supabase URL must use HTTPS");
+  }
+
+  const response = await fetchImpl(schemaUrl, {
+    headers: {
+      Accept: "application/openapi+json",
+      Authorization: `Bearer ${serviceRoleKey}`,
+      apikey: serviceRoleKey,
+    },
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    throw new Error(`Could not read production Supabase schema: HTTP ${response.status}`);
+  }
+
+  let document: unknown;
+  try {
+    document = await response.json();
+  } catch {
+    throw new Error("Production Supabase schema response was not valid JSON");
+  }
+
+  if (!isRecord(document)) {
+    throw new Error("Production Supabase schema response did not contain OpenAPI paths");
+  }
+
+  const paths = document.paths;
+  if (!isRecord(paths)) {
+    throw new Error("Production Supabase schema response did not contain OpenAPI paths");
+  }
+
+  const missingPaths = requiredPaths.filter((path) => !(path in paths));
+  if (missingPaths.length > 0) {
+    throw new Error(
+      `Production Supabase schema is missing required paths: ${missingPaths.join(", ")}`
+    );
+  }
+
+  return { checked: true, pathCount: requiredPaths.length };
+}


### PR DESCRIPTION
## What changed

- add a production-only Supabase OpenAPI contract check covering the 21 tables and RPCs used by Unicon
- run that check before every Vercel production build
- skip live schema access for preview, local, and ordinary GitHub CI builds
- add a source-contract test so new `.from(...)` and `.rpc(...)` calls must be represented in the production schema contract

## Why

The Stripe webhook code and its migration shipped together, but the migration was never applied to production. That allowed a deployment whose runtime schema dependency did not exist, causing every Stripe delivery to return 500.

The new build gate fails closed before a production deployment can be promoted when a required Supabase table or RPC is missing. While validating it, the gate also found the existing `accept_team_invite_atomic` RPC drift; the repository's email-bound migration has now been applied to production and the 21-path check passes live.

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:coverage` — 33 files, 132 tests
- `pnpm build`
- production schema check — 21 paths

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/webrenew/codesmith/unicon/pr/198"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787178721&installation_model_id=20495&pr_number=198&repository=webrenew%2Funicon&return_to=https%3A%2F%2Fgithub.com%2Fwebrenew%2Funicon%2Fpull%2F198&signature=a92cdf8ab4579650cafb79308ed23a941d7fb727b18cce5699191123bf695795"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->