### PR TITLE
fix: wrap conditional button text in spans to survive Google Translate DOM mutations

### DIFF
--- a/src/app/invite/[token]/accept-invite-button.tsx
+++ b/src/app/invite/[token]/accept-invite-button.tsx
@@ -62,7 +62,7 @@ export function AcceptInviteButton({ token, teamName }: AcceptInviteButtonProps)
         {status === "loading" ? (
           <Loader2Icon className="w-4 h-4 animate-spin" />
         ) : null}
-        Accept Invite
+        <span>Accept Invite</span>
       </button>
       {error && (
         <p className="text-xs text-red-600 dark:text-red-400">{error}</p>

--- a/src/components/bundles/bundle-browser.tsx
+++ b/src/components/bundles/bundle-browser.tsx
@@ -222,7 +222,7 @@ export function BundleBrowser({ bundle, categories, initialIcons, totalIconCount
               ) : (
                 <CheckIcon className="w-4 h-4" />
               )}
-              Save changes
+              <span>Save changes</span>
             </button>
           )}
         </div>

--- a/src/components/bundles/bundle-editor.tsx
+++ b/src/components/bundles/bundle-editor.tsx
@@ -314,7 +314,7 @@ export function BundleEditor({ bundle, onUpdate }: BundleEditorProps) {
             ) : (
               <CheckIcon className="w-4 h-4" />
             )}
-            Save changes
+            <span>Save changes</span>
           </button>
         )}
       </div>

--- a/src/components/copy-page-button.tsx
+++ b/src/components/copy-page-button.tsx
@@ -41,15 +41,18 @@ export function CopyPageButton({ markdown, className }: CopyPageButtonProps) {
       )}
       aria-label={copied ? "Copied page content" : "Copy page as Markdown"}
     >
+      {/* Text nodes are wrapped in spans so DOM-mutating extensions (e.g. Google
+          Translate wrapping text in <font> tags) can't detach React's node
+          references and crash reconciliation with removeChild/insertBefore. */}
       {copied ? (
         <>
           <CheckIcon className="w-3.5 h-3.5" />
-          Copied!
+          <span>Copied!</span>
         </>
       ) : (
         <>
           <CopyIcon className="w-3.5 h-3.5" />
-          Copy Page
+          <span>Copy Page</span>
         </>
       )}
     </button>

--- a/src/components/icons/icon-cart.tsx
+++ b/src/components/icons/icon-cart.tsx
@@ -586,7 +586,7 @@ export function IconCart({ items, onRemove, onClear, onAddPack, isOpen, onClose 
               className="flex-1 flex items-center justify-center gap-2 px-4 py-2.5 bg-black/10 dark:bg-white/10 hover:bg-black/15 dark:hover:bg-white/15 text-black dark:text-white rounded-lg text-sm font-mono transition-colors"
             >
               {copied ? <CheckIcon className="w-4 h-4" /> : <CopyIcon className="w-4 h-4" />}
-              {copied ? "Copied!" : "Copy"}
+              <span>{copied ? "Copied!" : "Copy"}</span>
             </button>
             <button
               onClick={handleDownload}

--- a/src/components/icons/icon-detail-dialog.tsx
+++ b/src/components/icons/icon-detail-dialog.tsx
@@ -305,7 +305,7 @@ defineProps<{
                 ) : (
                   <CopyIcon className="mr-2 h-4 w-4" />
                 )}
-                SVG
+                <span>SVG</span>
               </Button>
 
               <Button
@@ -318,7 +318,7 @@ defineProps<{
                 ) : (
                   <CopyIcon className="mr-2 h-4 w-4" />
                 )}
-                React
+                <span>React</span>
               </Button>
 
               <Button
@@ -331,7 +331,7 @@ defineProps<{
                 ) : (
                   <CopyIcon className="mr-2 h-4 w-4" />
                 )}
-                Vue
+                <span>Vue</span>
               </Button>
 
               <Button
@@ -344,7 +344,7 @@ defineProps<{
                 ) : (
                   <CopyIcon className="mr-2 h-4 w-4" />
                 )}
-                Svelte
+                <span>Svelte</span>
               </Button>
             </div>
 
@@ -358,7 +358,7 @@ defineProps<{
               ) : (
                 <CopyIcon className="mr-2 h-4 w-4" />
               )}
-              Usage Example
+              <span>Usage Example</span>
             </Button>
           </div>
 

--- a/src/components/icons/save-bundle-dialog.tsx
+++ b/src/components/icons/save-bundle-dialog.tsx
@@ -152,12 +152,12 @@ export function SaveBundleDialog({
             {isSaving ? (
               <>
                 <Loader2Icon className="w-4 h-4 animate-spin" />
-                Saving...
+                <span>Saving...</span>
               </>
             ) : (
               <>
                 <PackageIcon className="w-4 h-4" />
-                Save Bundle
+                <span>Save Bundle</span>
               </>
             )}
           </button>

--- a/src/components/icons/styled-icon.tsx
+++ b/src/components/icons/styled-icon.tsx
@@ -298,12 +298,12 @@ export function ${componentName}({ className, ...props }: SVGProps<SVGSVGElement
                 {isSelected ? (
                   <>
                     <MinusIcon className="mr-2 h-4 w-4" />
-                    Remove from bundle
+                    <span>Remove from bundle</span>
                   </>
                 ) : (
                   <>
                     <PlusIcon className="mr-2 h-4 w-4" />
-                    Add to bundle
+                    <span>Add to bundle</span>
                   </>
                 )}
               </ContextMenuItem>
@@ -316,7 +316,7 @@ export function ${componentName}({ className, ...props }: SVGProps<SVGSVGElement
             ) : (
               <CopyIcon className="mr-2 h-4 w-4" />
             )}
-            Copy SVG
+            <span>Copy SVG</span>
           </ContextMenuItem>
           <ContextMenuItem onClick={handleCopyComponent}>
             {copied === "component" ? (
@@ -324,7 +324,7 @@ export function ${componentName}({ className, ...props }: SVGProps<SVGSVGElement
             ) : (
               <CopyIcon className="mr-2 h-4 w-4" />
             )}
-            Copy React component
+            <span>Copy React component</span>
           </ContextMenuItem>
           <ContextMenuItem onClick={handleCopyUsage}>
             {copied === "usage" ? (
@@ -332,7 +332,7 @@ export function ${componentName}({ className, ...props }: SVGProps<SVGSVGElement
             ) : (
               <CopyIcon className="mr-2 h-4 w-4" />
             )}
-            Copy usage example
+            <span>Copy usage example</span>
           </ContextMenuItem>
           {icon.brandColor && (
             <ContextMenuItem onClick={() => icon.brandColor && handleCopy(icon.brandColor, "color")}>
@@ -344,7 +344,7 @@ export function ${componentName}({ className, ...props }: SVGProps<SVGSVGElement
                   style={{ backgroundColor: icon.brandColor }}
                 />
               )}
-              Copy brand color
+              <span>Copy brand color</span>
             </ContextMenuItem>
           )}
           <ContextMenuSeparator />
@@ -354,7 +354,7 @@ export function ${componentName}({ className, ...props }: SVGProps<SVGSVGElement
             ) : (
               <SparklesIcon className="mr-2 h-4 w-4" />
             )}
-            Copy prompt
+            <span>Copy prompt</span>
           </ContextMenuItem>
           <ContextMenuSeparator />
           <ContextMenuItem onClick={handleOpenInV0}>

--- a/src/components/packs/pack-card.tsx
+++ b/src/components/packs/pack-card.tsx
@@ -103,10 +103,12 @@ export function PackCard({ pack, onAddPack }: PackCardProps) {
             <TerminalIcon className="w-3.5 h-3.5 text-black/40 dark:text-white/40 group-hover/cmd:text-black/60 dark:group-hover/cmd:text-white/60 shrink-0" />
           )}
           <span className="text-[11px] font-mono text-black/50 dark:text-white/50 truncate">
-            {copiedCommand ? "Copied!" : (
+            {copiedCommand ? (
+              <span>Copied!</span>
+            ) : (
               <>
                 <span className="dark:text-[var(--accent-mint)]">npx</span>
-                {command.slice(3)}
+                <span>{command.slice(3)}</span>
               </>
             )}
           </span>


### PR DESCRIPTION
## Summary
Fixes [Sentry UNICON-A](https://webrenew.sentry.io/issues/7634313200/): `NotFoundError: Failed to execute 'removeChild' on 'Node'` on `/docs/cli`.

A user browsing with Google Translate active (page translated to Arabic) clicked the **Copy Page** button. Translate replaces text nodes with `<font>` wrappers, detaching React's node references — so when the button swapped `CopyIcon` + "Copy Page" for `CheckIcon` + "Copied!", React's `insertBefore`/`removeChild` threw `NotFoundError` and crashed the page (facebook/react#11538).

## Fix
Wrap bare text siblings of conditionally swapped icons/loaders in `<span>`, so React only ever inserts/removes elements (which remain valid children after Translate mutates their contents). Same pattern already used in `packs-grid.tsx`.

Fixed the crash site plus every other instance of the same vulnerable shape:
- `copy-page-button.tsx` (crash site, with explanatory comment)
- `icon-cart.tsx`, `pack-card.tsx`, `styled-icon.tsx` (6 menu items), `icon-detail-dialog.tsx` (5 buttons)
- `bundle-browser.tsx` / `bundle-editor.tsx` (Save changes), `save-bundle-dialog.tsx`, `accept-invite-button.tsx`

Icon-only swaps and sole-text-child updates were audited and left alone — they're structurally safe.

## Verification
- `pnpm lint`, `pnpm typecheck`, `pnpm build` all pass
- `pnpm test`: 136/136 pass