### PR TITLE
test: harden copy-page-button suite against timer and stub leaks

### DIFF
--- a/src/components/copy-page-button.test.tsx
+++ b/src/components/copy-page-button.test.tsx
@@ -1,5 +1,7 @@
-import { fireEvent, render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Mock } from "vitest";
+import { logger } from "@/lib/logger";
 import { CopyPageButton } from "./copy-page-button";
 
 /**
@@ -28,12 +30,32 @@ function simulateGoogleTranslate(root: HTMLElement) {
   }
 }
 
+const originalClipboard = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+
 describe("CopyPageButton", () => {
   beforeEach(() => {
+    // shouldAdvanceTime keeps findByRole's waitFor polling working under fake timers
+    vi.useFakeTimers({ shouldAdvanceTime: true });
     Object.defineProperty(navigator, "clipboard", {
       value: { writeText: vi.fn().mockResolvedValue(undefined) },
       configurable: true,
     });
+  });
+
+  afterEach(() => {
+    // Drain the component's 2s reset timer before jsdom teardown — pending
+    // timers firing after teardown are a documented CI flake in this repo
+    // (see src/__tests__/setup.ts).
+    act(() => {
+      vi.runOnlyPendingTimers();
+    });
+    vi.useRealTimers();
+    if (originalClipboard) {
+      Object.defineProperty(navigator, "clipboard", originalClipboard);
+    } else {
+      delete (navigator as { clipboard?: unknown }).clipboard;
+    }
+    vi.restoreAllMocks();
   });
 
   it("should toggle to copied state when clicked", async () => {
@@ -45,6 +67,37 @@ describe("CopyPageButton", () => {
       await screen.findByRole("button", { name: "Copied page content" })
     ).toBeInTheDocument();
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith("# Docs");
+  });
+
+  it("should revert to the copy label after 2 seconds", async () => {
+    render(<CopyPageButton markdown="# Docs" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy page as Markdown" }));
+    expect(
+      await screen.findByRole("button", { name: "Copied page content" })
+    ).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(
+      screen.getByRole("button", { name: "Copy page as Markdown" })
+    ).toBeInTheDocument();
+  });
+
+  it("should keep the copy label and log when the clipboard write fails", async () => {
+    const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+    render(<CopyPageButton markdown="# Docs" />);
+    const button = screen.getByRole("button", { name: "Copy page as Markdown" });
+    (navigator.clipboard.writeText as Mock).mockRejectedValue(new Error("denied"));
+
+    fireEvent.click(button);
+
+    await waitFor(() => expect(errorSpy).toHaveBeenCalled());
+    expect(
+      screen.getByRole("button", { name: "Copy page as Markdown" })
+    ).toBeInTheDocument();
   });
 
   it("should not crash when clicked after Google Translate rewrites text nodes", async () => {


### PR DESCRIPTION
Follow-up to #201, addressing all three review findings:

1. **Dangling 2s reset timer** — the suite now runs fake timers (`shouldAdvanceTime: true` so `findByRole` polling still works) and drains pending timers in `afterEach`, eliminating the leaked-timer flake class documented in `src/__tests__/setup.ts`.
2. **Unrestored clipboard stub** — the original `navigator.clipboard` descriptor is captured once and restored after each test; `vi.restoreAllMocks()` added.
3. **Untested rejection branch** — new test mocks `writeText` rejection and asserts the label stays "Copy page as Markdown" and `logger.error` fires.

Bonus enabled by fake timers: asserts the button reverts to the copy label after the 2000ms timeout.

4 tests passing; full suite 140/140, lint/typecheck/build green.